### PR TITLE
Fix Appnavhost rendermap ci

### DIFF
--- a/app/src/androidTest/java/com/swent/mapin/navigationTests/AppNavHostTest.kt
+++ b/app/src/androidTest/java/com/swent/mapin/navigationTests/AppNavHostTest.kt
@@ -15,7 +15,7 @@ class AppNavHostTest {
   @Test
   fun startsOnAuth_whenNotLoggedIn() {
     composeTestRule.setContent {
-      AppNavHost(navController = rememberNavController(), isLoggedIn = false)
+      AppNavHost(navController = rememberNavController(), isLoggedIn = false, renderMap = false)
     }
 
     composeTestRule
@@ -26,7 +26,7 @@ class AppNavHostTest {
   @Test
   fun startsOnMap_whenLoggedIn() {
     composeTestRule.setContent {
-      AppNavHost(navController = rememberNavController(), isLoggedIn = true)
+      AppNavHost(navController = rememberNavController(), isLoggedIn = true, renderMap = false)
     }
 
     composeTestRule.waitForIdle()
@@ -37,7 +37,7 @@ class AppNavHostTest {
   @Test
   fun navigatesToProfile_fromMap() {
     composeTestRule.setContent {
-      AppNavHost(navController = rememberNavController(), isLoggedIn = true)
+      AppNavHost(navController = rememberNavController(), isLoggedIn = true, renderMap = false)
     }
 
     composeTestRule.waitForIdle()
@@ -57,7 +57,7 @@ class AppNavHostTest {
   @Test
   fun logout_navigatesBackToAuth() {
     composeTestRule.setContent {
-      AppNavHost(navController = rememberNavController(), isLoggedIn = true)
+      AppNavHost(navController = rememberNavController(), isLoggedIn = true, renderMap = false)
     }
 
     composeTestRule.waitForIdle()
@@ -85,7 +85,7 @@ class AppNavHostTest {
   @Test
   fun logout_clearsBackStack() {
     composeTestRule.setContent {
-      AppNavHost(navController = rememberNavController(), isLoggedIn = true)
+      AppNavHost(navController = rememberNavController(), isLoggedIn = true, renderMap = false)
     }
 
     composeTestRule.waitForIdle()
@@ -114,7 +114,7 @@ class AppNavHostTest {
   @Test
   fun logout_fromProfile_cannotNavigateBackToMap() {
     composeTestRule.setContent {
-      AppNavHost(navController = rememberNavController(), isLoggedIn = true)
+      AppNavHost(navController = rememberNavController(), isLoggedIn = true, renderMap = false)
     }
 
     composeTestRule.waitForIdle()

--- a/app/src/main/java/com/swent/mapin/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/swent/mapin/navigation/AppNavHost.kt
@@ -13,6 +13,7 @@ import com.swent.mapin.ui.profile.ProfileScreen
 fun AppNavHost(
     navController: NavHostController = rememberNavController(),
     isLoggedIn: Boolean,
+    renderMap: Boolean = true
 ) {
   val startDest = if (isLoggedIn) Route.Map.route else Route.Auth.route
 
@@ -28,7 +29,9 @@ fun AppNavHost(
     }
 
     composable(Route.Map.route) {
-      MapScreen(onNavigateToProfile = { navController.navigate(Route.Profile.route) })
+      MapScreen(
+          onNavigateToProfile = { navController.navigate(Route.Profile.route) },
+          renderMap = renderMap)
     }
 
     composable(Route.Profile.route) {


### PR DESCRIPTION
**Issue**: logout_navigatesBackToAuth in AppNavHostTest passes locally but not on CI.

**Root Cause**

The AppNavHost was creating MapScreen with renderMap = true (default), which triggers the graphically intensive Mapbox rendering. This causes a process crash in CI environments that can't handle the GPU requirements. 

**Solution Applied**

1. Added renderMap: Boolean = true parameter to AppNavHost
2. Passed renderMap parameter through to MapScreen. 
3. Updated all tests in AppNavHostTest to use renderMap = false.

This follows the same pattern we used to fix the previous satellite mode crash.