### PR TITLE
Revert "feat: add event price"

### DIFF
--- a/app/src/androidTest/java/com/swent/mapin/ui/event/addEvent/AddEventScreenTests.kt
+++ b/app/src/androidTest/java/com/swent/mapin/ui/event/addEvent/AddEventScreenTests.kt
@@ -69,10 +69,6 @@ class AddEventScreenTests {
         .performScrollTo()
         .assertIsDisplayed()
     composeTestRule
-        .onNodeWithTag(AddEventScreenTestTags.INPUT_EVENT_PRICE)
-        .performScrollTo()
-        .assertIsDisplayed()
-    composeTestRule
         .onNodeWithTag(AddEventScreenTestTags.INPUT_EVENT_LOCATION)
         .performScrollTo()
         .assertIsDisplayed()
@@ -224,34 +220,6 @@ class AddEventScreenTests {
   }
 
   @Test
-  fun validPriceInputWorks() {
-    composeTestRule.onNodeWithTag(AddEventScreenTestTags.INPUT_EVENT_TITLE).performTextInput("a")
-    composeTestRule.onNodeWithTag(AddEventScreenTestTags.INPUT_EVENT_TITLE).performTextClearance()
-    val tagNode = composeTestRule.onNodeWithTag(AddEventScreenTestTags.INPUT_EVENT_PRICE)
-    tagNode.performScrollTo()
-    tagNode.assertIsDisplayed()
-    tagNode.performTextInput("InvalidPrice")
-    tagNode.performTextClearance()
-    tagNode.performTextInput("3.0")
-    composeTestRule
-        .onNodeWithTag(AddEventScreenTestTags.ERROR_MESSAGE)
-        .assert(!hasText("Price", substring = true, ignoreCase = true))
-  }
-
-  @Test
-  fun invalidPriceInputDoesNotWork() {
-    composeTestRule.onNodeWithTag(AddEventScreenTestTags.INPUT_EVENT_TITLE).performTextInput("a")
-    composeTestRule.onNodeWithTag(AddEventScreenTestTags.INPUT_EVENT_TITLE).performTextClearance()
-    val tagNode = composeTestRule.onNodeWithTag(AddEventScreenTestTags.INPUT_EVENT_PRICE)
-    tagNode.performScrollTo()
-    tagNode.assertIsDisplayed()
-    tagNode.performTextInput("InvalidPrice")
-    composeTestRule
-        .onNodeWithTag(AddEventScreenTestTags.ERROR_MESSAGE)
-        .assert(hasText("Price", substring = true, ignoreCase = true))
-  }
-
-  @Test
   fun invalidInputsKeepSaveButtonDisabled() {
     composeTestRule.onNodeWithTag(AddEventScreenTestTags.INPUT_EVENT_TITLE).performTextInput("")
     composeTestRule
@@ -271,7 +239,6 @@ class SaveEventTests {
     val testDescription = "Some description"
     val testTags = listOf("tag1", "tag2")
     val isPublic = true
-    val price = 0.0
     val currentUserId = "FakeUserId"
 
     var onDoneCalled = false
@@ -286,8 +253,7 @@ class SaveEventTests {
         currentUserId = currentUserId,
         tags = testTags,
         isPublic = isPublic,
-        onDone = onDone,
-        price = price)
+        onDone = onDone)
 
     verify { mockViewModel.addEvent(any<Event>()) }
     assert(onDoneCalled)
@@ -301,7 +267,6 @@ class SaveEventTests {
     val testDescription = "Some description"
     val testTags = listOf("tag1", "tag2")
     val isPublic = true
-    val price = 0.0
 
     val currentUserId: String? = null // simulate not logged in
 
@@ -317,8 +282,7 @@ class SaveEventTests {
         currentUserId = currentUserId,
         tags = testTags,
         isPublic = isPublic,
-        onDone = onDone,
-        price = price)
+        onDone = onDone)
 
     verify(exactly = 0) { mockViewModel.addEvent(any<Event>()) } // should NOT be called
     assert(!onDoneCalled)

--- a/app/src/main/java/com/swent/mapin/ui/event/AddEventScreen.kt
+++ b/app/src/main/java/com/swent/mapin/ui/event/AddEventScreen.kt
@@ -9,8 +9,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.imePadding
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -71,7 +69,6 @@ object AddEventScreenTestTags {
   const val INPUT_EVENT_DESCRIPTION = "inputEventDescription"
   const val INPUT_EVENT_TAG = "inputEventTag"
   const val INPUT_EVENT_LOCATION = "inputEventLocation"
-  const val INPUT_EVENT_PRICE = "inputEventPrice"
   const val EVENT_CANCEL = "eventCancel"
   const val EVENT_SAVE = "eventSave"
   const val ERROR_MESSAGE = "errorMessage"
@@ -94,10 +91,7 @@ object AddEventScreenTestTags {
  * @param placeholderString The placeholder text to display when the field is empty.
  * @param modifier [Modifier] for customizing layout or styling.
  * @param isLocation Whether this field is a location field (affects validation/formatting).
- * @param isPrice Whether this field is a price field
  * @param isTag Whether this field represents a tag input (affects validation/formatting).
- * @param locationQuery Query callback for the location
- * @param singleLine Whether the text field should show text in a single line or not
  */
 @Composable
 fun AddEventTextField(
@@ -106,7 +100,6 @@ fun AddEventTextField(
     placeholderString: String,
     modifier: Modifier = Modifier,
     isLocation: Boolean = false,
-    isPrice: Boolean = false,
     isTag: Boolean = false,
     locationQuery: () -> Unit = {},
     singleLine: Boolean = false
@@ -121,8 +114,6 @@ fun AddEventTextField(
           locationQuery()
         } else if (isTag) {
           error.value = !isValidTagInput(it)
-        } else if (isPrice) {
-          error.value = !isValidPriceInput(it)
         } else {
           error.value = textField.value.isBlank()
         }
@@ -140,8 +131,6 @@ fun AddEventTextField(
  *
  * @param selectedDate A [MutableState] holding the selected date as a string in the format
  *   `dd/MM/yyyy`.
- * @param onDateClick Callback triggered when the user clicks the button
- * @param onDateChanged Callback changed when the date value changes
  */
 @Composable
 fun FutureDatePickerButton(
@@ -203,8 +192,6 @@ fun FutureDatePickerButton(
  *
  * @param selectedTime The [MutableState] storing the currently selected time as a string (formatted
  *   as HHmm).
- * @param onTimeClick Callback triggered when the user clicks the button
- * @param onTimeChanged Callback triggered when the time value changes
  */
 @Composable
 fun TimePickerButton(
@@ -295,10 +282,7 @@ private fun PublicSwitch(
  * required fields are missing or invalid.
  *
  * @param modifier [Modifier] to customize the pop-up layout.
- * @param eventViewModel ViewModel for events
- * @param locationViewModel ViewModel for Locations
- * @param onCancel callback triggered when the user cancels the event creation
- * @param onDone callback triggered when the user is done with the event creation
+ * @param onDone callback triggered when the user is done with the event creation popup
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -315,7 +299,6 @@ fun AddEventScreen(
   val date = remember { mutableStateOf("") }
   val tag = remember { mutableStateOf("") }
   val time = remember { mutableStateOf("") }
-  val price = remember { mutableStateOf("") }
   val isPublic = remember { mutableStateOf(true) }
 
   val dateError = remember { mutableStateOf(false) }
@@ -324,7 +307,6 @@ fun AddEventScreen(
   val descriptionError = remember { mutableStateOf(false) }
   val locationError = remember { mutableStateOf(false) }
   val tagError = remember { mutableStateOf(false) }
-  val priceError = remember { mutableStateOf(false) }
   val isLoggedIn = remember { mutableStateOf((Firebase.auth.currentUser != null)) }
 
   val locationExpanded = remember { mutableStateOf(false) }
@@ -344,8 +326,7 @@ fun AddEventScreen(
           time.value.isBlank() ||
           dateError.value ||
           date.value.isBlank() ||
-          tagError.value ||
-          priceError.value
+          tagError.value
 
   val showMissingFields =
       titleError.value ||
@@ -353,239 +334,204 @@ fun AddEventScreen(
           locationError.value ||
           timeError.value ||
           dateError.value ||
-          tagError.value ||
-          priceError.value
+          tagError.value
 
   val errorFields =
       listOfNotNull(
           if (titleError.value) stringResource(R.string.title_field) else null,
           if (dateError.value) stringResource(R.string.date_field) else null,
-          if (timeError.value) stringResource(R.string.time) else null,
           if (locationError.value) stringResource(R.string.location_field) else null,
           if (descriptionError.value) stringResource(R.string.description_field) else null,
           if (tagError.value) stringResource(R.string.tag_field) else null,
-          if (priceError.value) stringResource(R.string.price_field) else null)
+          if (timeError.value) stringResource(R.string.time) else null)
 
   val isEventValid = !error && isLoggedIn.value
   val isDateAndTimeValid =
       dateError.value || timeError.value || date.value.isBlank() || time.value.isBlank()
   val scrollState = rememberScrollState()
 
-  Column(
-      modifier =
-          modifier
-              .fillMaxWidth()
-              .verticalScroll(scrollState)
-              .imePadding()
-              .navigationBarsPadding()) {
-        // TopBar
-        Row(
-            modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically) {
-              IconButton(
-                  onClick = onCancel,
-                  modifier = Modifier.size(48.dp).testTag(AddEventScreenTestTags.EVENT_CANCEL)) {
-                    Icon(
-                        imageVector = Icons.Default.Close,
-                        contentDescription = "Cancel",
-                        tint = MaterialTheme.colorScheme.onSurface)
-                  }
+  Column(modifier = modifier.fillMaxWidth().verticalScroll(scrollState)) {
+    // TopBar
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically) {
+          IconButton(
+              onClick = onCancel,
+              modifier = Modifier.size(48.dp).testTag(AddEventScreenTestTags.EVENT_CANCEL)) {
+                Icon(
+                    imageVector = Icons.Default.Close,
+                    contentDescription = "Cancel",
+                    tint = MaterialTheme.colorScheme.onSurface)
+              }
 
-              Text(
-                  text = "New Event",
-                  style = MaterialTheme.typography.titleLarge,
-                  textAlign = TextAlign.Center,
-                  modifier = Modifier.weight(1f))
-
-              IconButton(
-                  onClick = {
-                    val sdf = SimpleDateFormat("dd/MM/yyyyHHmm", Locale.getDefault())
-                    sdf.timeZone = java.util.TimeZone.getDefault()
-                    val rawTime =
-                        if (time.value.contains("h")) time.value.replace("h", "") else time.value
-                    val parsed = runCatching { sdf.parse(date.value + rawTime) }.getOrNull()
-                    val timestamp = parsed?.let { Timestamp(it) } ?: Timestamp.now()
-                    saveEvent(
-                        eventViewModel,
-                        title.value,
-                        description.value,
-                        gotLocation.value,
-                        timestamp,
-                        Firebase.auth.currentUser?.uid,
-                        extractTags(tag.value),
-                        isPublic.value,
-                        onDone,
-                        price.value.toDoubleOrNull() ?: 0.0,
-                    )
-                  },
-                  enabled = isEventValid,
-                  modifier =
-                      Modifier.size(48.dp)
-                          .background(
-                              color =
-                                  if (isEventValid) MaterialTheme.colorScheme.primaryContainer
-                                  else MaterialTheme.colorScheme.surfaceVariant,
-                              shape = CircleShape)
-                          .testTag(AddEventScreenTestTags.EVENT_SAVE)) {
-                    Icon(
-                        imageVector = Icons.Default.Check,
-                        contentDescription = "Save",
-                        tint =
-                            if (isEventValid) MaterialTheme.colorScheme.onPrimaryContainer
-                            else MaterialTheme.colorScheme.onSurfaceVariant)
-                  }
-            }
-
-        Spacer(modifier = Modifier.padding(5.dp))
-        // Title field
-        Text(
-            text = stringResource(R.string.title_text),
-            style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.padding(bottom = 8.dp))
-        AddEventTextField(
-            title,
-            titleError,
-            stringResource(R.string.title_place_holder),
-            modifier = Modifier.testTag(AddEventScreenTestTags.INPUT_EVENT_TITLE),
-            singleLine = true)
-
-        Spacer(modifier = Modifier.padding(10.dp))
-        // Date and time fields
-
-        Text(
-            stringResource(R.string.date_text),
-            style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.padding(bottom = 8.dp))
-        if (isDateAndTimeValid) {
           Text(
-              stringResource(R.string.date_time_error),
-              style = MaterialTheme.typography.labelMedium,
-              color = Color.Red,
+              text = "New Event",
+              style = MaterialTheme.typography.titleLarge,
+              textAlign = TextAlign.Center,
+              modifier = Modifier.weight(1f))
+
+          IconButton(
+              onClick = {
+                val sdf = SimpleDateFormat("dd/MM/yyyyHHmm", Locale.getDefault())
+                sdf.timeZone = java.util.TimeZone.getDefault()
+                val rawTime =
+                    if (time.value.contains("h")) time.value.replace("h", "") else time.value
+                val parsed = runCatching { sdf.parse(date.value + rawTime) }.getOrNull()
+                val timestamp = parsed?.let { Timestamp(it) } ?: Timestamp.now()
+                saveEvent(
+                    eventViewModel,
+                    title.value,
+                    description.value,
+                    gotLocation.value,
+                    timestamp,
+                    Firebase.auth.currentUser?.uid,
+                    extractTags(tag.value),
+                    isPublic.value,
+                    onDone)
+              },
+              enabled = isEventValid,
               modifier =
-                  Modifier.padding(bottom = 8.dp).testTag(AddEventScreenTestTags.DATE_TIME_ERROR))
+                  Modifier.size(48.dp)
+                      .background(
+                          color =
+                              if (isEventValid) MaterialTheme.colorScheme.primaryContainer
+                              else MaterialTheme.colorScheme.surfaceVariant,
+                          shape = CircleShape)
+                      .testTag(AddEventScreenTestTags.EVENT_SAVE)) {
+                Icon(
+                    imageVector = Icons.Default.Check,
+                    contentDescription = "Save",
+                    tint =
+                        if (isEventValid) MaterialTheme.colorScheme.onPrimaryContainer
+                        else MaterialTheme.colorScheme.onSurfaceVariant)
+              }
         }
-        Row(
-            modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-            verticalAlignment = Alignment.CenterVertically) {
-              FutureDatePickerButton(
-                  date,
-                  onDateChanged = { dateError.value = (date.value.isBlank()) },
-              )
 
-              TimePickerButton(
-                  time,
-                  onTimeChanged = { timeError.value = (time.value.isBlank()) },
-              )
-            }
-        // Location Field
-        Text(
-            stringResource(R.string.location_text),
-            style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.padding(bottom = 8.dp))
-        LocationDropDownMenu(
-            location,
-            locationError,
-            locationViewModel,
-            locationExpanded,
-            locations,
-            gotLocation,
-        )
+    Spacer(modifier = Modifier.padding(5.dp))
+    // Title field
+    Text(
+        text = stringResource(R.string.title_text),
+        style = MaterialTheme.typography.labelMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.padding(bottom = 8.dp))
+    AddEventTextField(
+        title,
+        titleError,
+        stringResource(R.string.title_place_holder),
+        modifier = Modifier.testTag(AddEventScreenTestTags.INPUT_EVENT_TITLE),
+        singleLine = true)
 
-        Spacer(modifier = Modifier.padding(10.dp))
-        // Description field
-        Text(
-            stringResource(R.string.description_text),
-            style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.padding(bottom = 8.dp))
-        AddEventTextField(
-            description,
-            descriptionError,
-            stringResource(R.string.description_place_holder),
-            modifier =
-                Modifier.height(120.dp).testTag(AddEventScreenTestTags.INPUT_EVENT_DESCRIPTION),
-        )
+    Spacer(modifier = Modifier.padding(10.dp))
+    // Date and time fields
 
-        Spacer(modifier = Modifier.padding(10.dp))
-        // Tag Field
-        Text(
-            stringResource(R.string.tag_text),
-            style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.padding(bottom = 8.dp))
-        AddEventTextField(
-            tag,
-            tagError,
-            stringResource(R.string.add_tag_place_holder),
-            modifier = Modifier.height(80.dp).testTag(AddEventScreenTestTags.INPUT_EVENT_TAG),
-            isTag = true)
+    Text(
+        stringResource(R.string.date_text),
+        style = MaterialTheme.typography.labelMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.padding(bottom = 8.dp))
+    if (isDateAndTimeValid) {
+      Text(
+          stringResource(R.string.date_time_error),
+          style = MaterialTheme.typography.labelMedium,
+          color = Color.Red,
+          modifier =
+              Modifier.padding(bottom = 8.dp).testTag(AddEventScreenTestTags.DATE_TIME_ERROR))
+    }
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically) {
+          FutureDatePickerButton(
+              date,
+              onDateChanged = { dateError.value = (date.value.isBlank()) },
+          )
 
-        Spacer(modifier = Modifier.padding(bottom = 10.dp))
-        // Price field
-        Text(
-            stringResource(R.string.price_text),
-            style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.padding(bottom = 8.dp))
-        Row(verticalAlignment = Alignment.CenterVertically) {
-          AddEventTextField(
-              price,
-              priceError,
-              stringResource(R.string.price_place_holder),
-              modifier =
-                  Modifier.fillMaxWidth(0.3f).testTag(AddEventScreenTestTags.INPUT_EVENT_PRICE),
-              singleLine = true,
-              isPrice = true)
-          Spacer(modifier = Modifier.padding(horizontal = 5.dp))
-          Text(
-              stringResource(R.string.currency_switzerland),
-              color = MaterialTheme.colorScheme.onSurfaceVariant,
+          TimePickerButton(
+              time,
+              onTimeChanged = { timeError.value = (time.value.isBlank()) },
           )
         }
+    // Location Field
+    Text(
+        stringResource(R.string.location_text),
+        style = MaterialTheme.typography.labelMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.padding(bottom = 8.dp))
+    LocationDropDownMenu(
+        location,
+        locationError,
+        locationViewModel,
+        locationExpanded,
+        locations,
+        gotLocation,
+    )
 
-        Spacer(modifier = Modifier.padding(bottom = 5.dp))
+    Spacer(modifier = Modifier.padding(10.dp))
+    // Description field
+    Text(
+        stringResource(R.string.description_text),
+        style = MaterialTheme.typography.labelMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.padding(bottom = 8.dp))
+    AddEventTextField(
+        description,
+        descriptionError,
+        stringResource(R.string.description_place_holder),
+        modifier = Modifier.height(120.dp).testTag(AddEventScreenTestTags.INPUT_EVENT_DESCRIPTION),
+    )
 
-        // Public/Private switch
-        if (isPublic.value) {
-          PublicSwitch(
-              isPublic = isPublic.value,
-              onPublicChange = { isPublic.value = it },
-              "This event will be public",
-              "Others can see this event on the map",
-              Modifier.testTag(AddEventScreenTestTags.PUBLIC_SWITCH),
-              Modifier.testTag(AddEventScreenTestTags.PUBLIC_TEXT))
-        } else {
-          PublicSwitch(
-              isPublic = isPublic.value,
-              onPublicChange = { isPublic.value = it },
-              "This event will be private",
-              "Others will not see this event on the map",
-              Modifier.testTag(AddEventScreenTestTags.PUBLIC_SWITCH),
-              Modifier.testTag(AddEventScreenTestTags.PUBLIC_TEXT))
-        }
+    Spacer(modifier = Modifier.padding(10.dp))
+    // Tag Field
+    Text(
+        stringResource(R.string.tag_text),
+        style = MaterialTheme.typography.labelMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.padding(bottom = 8.dp))
+    AddEventTextField(
+        tag,
+        tagError,
+        stringResource(R.string.add_tag_place_holder),
+        modifier = Modifier.height(80.dp).testTag(AddEventScreenTestTags.INPUT_EVENT_TAG),
+        isTag = true)
 
-        // Error displaying
-        if (showMissingFields) {
-          Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.height(60.dp)) {
-            Spacer(modifier = Modifier.padding(2.dp))
-            Icon(
-                imageVector = Icons.Outlined.Info,
-                contentDescription = "Info",
-                tint = colorResource(R.color.red),
-                modifier = Modifier.size(20.dp))
-            Spacer(modifier = Modifier.padding(3.dp))
-            Text(
-                "The following fields are missing/incorrect: " + errorFields.joinToString(", "),
-                fontSize = 12.sp,
-                color = colorResource(R.color.red),
-                lineHeight = 14.sp,
-                modifier = Modifier.testTag(AddEventScreenTestTags.ERROR_MESSAGE))
-          }
-        }
+    Spacer(modifier = Modifier.padding(bottom = 5.dp))
+    // Public/Private switch
+    if (isPublic.value) {
+      PublicSwitch(
+          isPublic = isPublic.value,
+          onPublicChange = { isPublic.value = it },
+          "This event will be public",
+          "Others can see this event on the map",
+          Modifier.testTag(AddEventScreenTestTags.PUBLIC_SWITCH),
+          Modifier.testTag(AddEventScreenTestTags.PUBLIC_TEXT))
+    } else {
+      PublicSwitch(
+          isPublic = isPublic.value,
+          onPublicChange = { isPublic.value = it },
+          "This event will be private",
+          "Others will not see this event on the map",
+          Modifier.testTag(AddEventScreenTestTags.PUBLIC_SWITCH),
+          Modifier.testTag(AddEventScreenTestTags.PUBLIC_TEXT))
+    }
+
+    // Error displaying
+    if (showMissingFields) {
+      Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.height(60.dp)) {
+        Spacer(modifier = Modifier.padding(2.dp))
+        Icon(
+            imageVector = Icons.Outlined.Info,
+            contentDescription = "Info",
+            tint = colorResource(R.color.red),
+            modifier = Modifier.size(20.dp))
+        Spacer(modifier = Modifier.padding(3.dp))
+        Text(
+            "The following fields are missing/incorrect: " + errorFields.joinToString(", "),
+            fontSize = 12.sp,
+            color = colorResource(R.color.red),
+            lineHeight = 14.sp,
+            modifier = Modifier.testTag(AddEventScreenTestTags.ERROR_MESSAGE))
       }
+    }
+  }
 }

--- a/app/src/main/java/com/swent/mapin/ui/event/AddEventUtils.kt
+++ b/app/src/main/java/com/swent/mapin/ui/event/AddEventUtils.kt
@@ -24,17 +24,6 @@ fun isValidTagInput(input: String): Boolean {
 }
 
 /**
- * With help of GPT Helper function to check whether a given string input is a valid price (double)
- *
- * @param input The string input
- */
-fun isValidPriceInput(input: String): Boolean {
-  if (input.isBlank()) return true
-  val regex = """^\d+(\.\d+)?$""".toRegex()
-  return regex.matches(input.trim())
-}
-
-/**
  * With Help of GPT: Helper function that extracts individual tags from a valid input string.
  *
  * The input string is expected to follow the same format checked by [isValidTagInput], where each
@@ -90,8 +79,7 @@ fun saveEvent(
     currentUserId: String?,
     tags: List<String>,
     isPublic: Boolean,
-    onDone: () -> Unit,
-    price: Double = 0.0
+    onDone: () -> Unit
 ) {
   val uid = currentUserId ?: return
   val newEvent =
@@ -106,8 +94,7 @@ fun saveEvent(
           public = isPublic,
           ownerId = uid,
           imageUrl = null,
-          capacity = null,
-          price = price)
+          capacity = null)
   viewModel.addEvent(newEvent)
   onDone()
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,10 +14,6 @@
     <string name="description_field">Description</string>>
     <string name="tag_text">Tags (optional)</string>>
     <string name="tag_field">Tags</string>>
-    <string name="price_field">Price</string>
-    <string name="price_text">Price (optional)</string>
-    <string name="price_place_holder">Entry price:</string>
-    <string name="currency_switzerland">CHF</string>
     <string name="title_place_holder">Enter the name of your event:</string>>
     <string name="day_place_holder">DD</string>>
     <string name="month_place_holder">MM</string>>

--- a/app/src/test/java/com/swent/mapin/ui/AddEventUtilsTest.kt
+++ b/app/src/test/java/com/swent/mapin/ui/AddEventUtilsTest.kt
@@ -1,7 +1,10 @@
-package com.swent.mapin.ui.event
+package com.swent.mapin.ui
 
 import com.swent.mapin.model.Location
-import junit.framework.TestCase
+import com.swent.mapin.ui.event.extractTags
+import com.swent.mapin.ui.event.isValidLocation
+import com.swent.mapin.ui.event.isValidTagInput
+import junit.framework.TestCase.assertFalse
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -28,12 +31,12 @@ class AddEventUtilsTest {
 
   @Test
   fun `returns false for tags missing hash or invalid format`() {
-    TestCase.assertFalse(isValidTagInput("food")) // missing #
-    TestCase.assertFalse(isValidTagInput("#food travel")) // second missing #
-    TestCase.assertFalse(isValidTagInput("#food,travel")) // invalid second
-    TestCase.assertFalse(isValidTagInput("#")) // incomplete tag
-    TestCase.assertFalse(isValidTagInput("#food,,")) // trailing commas
-    TestCase.assertFalse(isValidTagInput("#food, #")) // dangling #
+    assertFalse(isValidTagInput("food")) // missing #
+    assertFalse(isValidTagInput("#food travel")) // second missing #
+    assertFalse(isValidTagInput("#food,travel")) // invalid second
+    assertFalse(isValidTagInput("#")) // incomplete tag
+    assertFalse(isValidTagInput("#food,,")) // trailing commas
+    assertFalse(isValidTagInput("#food, #")) // dangling #
   }
 
   // ---------- Tests for extractTags ----------
@@ -72,36 +75,12 @@ class AddEventUtilsTest {
   @Test
   fun `returns false when location not in list`() {
     val locations = listOf(Location("Berlin", 0.0, 0.0), Location("Rome", 0.0, 0.0))
-    TestCase.assertFalse(isValidLocation("Madrid", locations))
+    assertFalse(isValidLocation("Madrid", locations))
   }
 
   @Test
   fun `returns false for empty location list`() {
     val locations = emptyList<Location>()
-    TestCase.assertFalse(isValidLocation("Anything", locations))
-  }
-
-  @Test
-  fun `returns false for invalid price`() {
-    val invalidPrice = "3.0price"
-    val invalidPrice2 = "3.0f"
-    val invalidPrice3 = "price"
-    val invalidPrice4 = "price0.0"
-    TestCase.assertFalse(isValidPriceInput(invalidPrice))
-    TestCase.assertFalse(isValidPriceInput(invalidPrice2))
-    TestCase.assertFalse(isValidPriceInput(invalidPrice3))
-    TestCase.assertFalse(isValidPriceInput(invalidPrice4))
-  }
-
-  @Test
-  fun `returns true for valid price`() {
-    val validPrice = "3.0"
-    val validPrice2 = "0"
-    val validPrice3 = "0.0"
-    val validPrice4 = "10"
-    TestCase.assertTrue(isValidPriceInput(validPrice))
-    TestCase.assertTrue(isValidPriceInput(validPrice2))
-    TestCase.assertTrue(isValidPriceInput(validPrice3))
-    TestCase.assertTrue(isValidPriceInput(validPrice4))
+    assertFalse(isValidLocation("Anything", locations))
   }
 }

--- a/app/src/test/java/com/swent/mapin/ui/EventViewModelTests.kt
+++ b/app/src/test/java/com/swent/mapin/ui/EventViewModelTests.kt
@@ -1,9 +1,10 @@
-package com.swent.mapin.ui.event
+package com.swent.mapin.ui
 
 import com.google.firebase.Timestamp
 import com.swent.mapin.model.Location
 import com.swent.mapin.model.event.Event
 import com.swent.mapin.model.event.EventRepository
+import com.swent.mapin.ui.event.EventViewModel
 import com.swent.mapin.ui.filters.Filters
 import kotlin.test.assertEquals
 import kotlinx.coroutines.Dispatchers
@@ -76,7 +77,7 @@ class EventViewModelTests {
                 uid = "E1",
                 title = "Test Event",
                 description = "Desc",
-                date = Timestamp.Companion.now(),
+                date = Timestamp.now(),
                 location = Location("Loc", 1.0, 2.0),
                 tags = listOf("tag1"),
                 public = true,
@@ -109,7 +110,7 @@ class EventViewModelTests {
                 uid = "E1",
                 title = "Test Event",
                 description = "Desc",
-                date = Timestamp.Companion.now(),
+                date = Timestamp.now(),
                 location = Location("Loc", 1.0, 2.0),
                 tags = emptyList(),
                 public = true,


### PR DESCRIPTION
Reverts swent-mapin/Map-In#225 to fix small UI bug related to user-friendly text field-centering when a user wishes to type in Add Event Screen.

@e-bernier Could be helpful to take reference to line 376 of the AddEventScreen for your PR which had similar issues as well:
`Scaffold(contentWindowInsets = WindowInsets.ime) { padding ->`
