### PR TITLE
Fix event detail opening in FULL instead of MEDIUM from search

### DIFF
--- a/app/src/main/java/com/swent/mapin/ui/map/MapScreenViewModel.kt
+++ b/app/src/main/java/com/swent/mapin/ui/map/MapScreenViewModel.kt
@@ -658,15 +658,13 @@ class MapScreenViewModel(
   }
 
   fun onEventPinClicked(event: Event, forceZoom: Boolean = false) {
-    viewModelScope.launch {
-      // Save current sheet state before opening event detail
-      _sheetStateBeforeEvent = bottomSheetState
-      _selectedEvent = event
-      _organizerName = "User ${event.ownerId.take(6)}"
-      setBottomSheetState(BottomSheetState.MEDIUM)
+    // Save current sheet state before opening event detail
+    _sheetStateBeforeEvent = bottomSheetState
+    _selectedEvent = event
+    _organizerName = "User ${event.ownerId.take(6)}"
+    setBottomSheetState(BottomSheetState.MEDIUM)
 
-      cameraController.centerOnEvent(event, forceZoom)
-    }
+    viewModelScope.launch { cameraController.centerOnEvent(event, forceZoom) }
   }
 
   /**
@@ -679,6 +677,8 @@ class MapScreenViewModel(
     wasEditingBeforeEvent = searchStateController.clearSearchOnExitFull
     searchStateController.saveRecentEvent(event.uid, event.title)
     searchStateController.markSearchCommitted()
+    // Clear focus to hide keyboard before showing event detail
+    clearSearchFieldFocus()
     onEventPinClicked(event, forceZoom = true)
   }
 


### PR DESCRIPTION
## Description
Fixed bug where clicking a search result would show event details in FULL mode instead of MEDIUM mode (preview).

**Related Issue:** Closes #352

---

## Changes

**Implementation:**
- Moved state updates in `onEventPinClicked` outside coroutine scope to ensure synchronous execution
- Only camera operations remain async in coroutine
- Added keyboard dismissal in `onEventClickedFromSearch` for cleaner UX

**Tests:**
- All existing unit tests pass
- Verified `onEventClickedFromSearch` test asserts MEDIUM state

---

## Testing
- [x] Unit tests pass
- [ ] Instrumentation tests pass
- [x] Manual testing completed
- [x] Coverage maintained (≥80%)

**Test summary:** All existing unit tests pass, including the test that verifies bottom sheet state is MEDIUM after clicking search result.

---

## Checklist
- [x] Sufficient documentation and minimal inline comments
- [x] All tests passing
- [x] No new warnings
- [ ] If related issue exists: issue has all labels, fields, and milestone filled

🤖 Generated with [Claude Code](https://claude.com/claude-code)