### PR TITLE
Fix bottom sheet IME padding regression

### DIFF
--- a/app/src/main/java/com/swent/mapin/ui/map/BottomSheetContent.kt
+++ b/app/src/main/java/com/swent/mapin/ui/map/BottomSheetContent.kt
@@ -140,6 +140,8 @@ fun BottomSheetContent(
     recentItems: List<RecentItem> = emptyList(),
     onRecentSearchClick: (String) -> Unit = {},
     onRecentEventClick: (String) -> Unit = {},
+    topCategories: List<String> = emptyList(),
+    onCategoryClick: (String) -> Unit = {},
     onClearRecentSearches: () -> Unit = {},
     // Memory form and events
     currentScreen: BottomSheetScreen = BottomSheetScreen.MAIN_CONTENT,
@@ -323,8 +325,6 @@ fun BottomSheetContent(
                                   onRecentSearchClick = onRecentSearchClick,
                                   onRecentEventClick = onRecentEventClick,
                                   onShowAllRecents = { showAllRecents = true },
-                                  topCategories = topCategories,
-                                  onCategoryClick = onCategoryClick,
                                   onEventClick = onEventClick)
                             } else {
                               val density = LocalDensity.current


### PR DESCRIPTION
## Description
Prevents the map bottom sheet from keeping IME padding once the keyboard is dismissed so full mode no longer shows a white block after exiting search.

**Related Issue:** Closes #432
EDIT: Turns out #451 is the better fix.

---

## Changes
**Implementation:**
- Apply IME bottom padding only when `WindowInsets.ime` reports a bottom inset in the full-state sheet content.
- Replace unconditional `imePadding()` with density-aware padding to avoid persistent whitespace after keyboard close.

**Tests:**
- Not run (pending manual UI verification)

---

## Testing
- [ ] Unit tests pass
- [ ] Instrumentation tests pass
- [ ] Manual testing completed
- [ ] Coverage maintained (≥80%)

**Test summary:** Not run; manual verification pending.

---

## Screenshots/Videos
See prior problem video in the related issue.

---

## Checklist
- [x] Sufficient documentation and minimal inline comments
- [ ] All tests passing
- [x] No new warnings
- [x] If related issue exists: issue has all labels, fields, and milestone filled
