### PR TITLE
Fix IME white block when keyboard is dismissed

### DIFF
--- a/app/src/main/java/com/swent/mapin/ui/map/BottomSheetContent.kt
+++ b/app/src/main/java/com/swent/mapin/ui/map/BottomSheetContent.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.ime
+import androidx.compose.foundation.layout.isImeVisible
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -303,189 +304,203 @@ fun BottomSheetContent(
                         },
                         onBack = { showAllRecents = false })
                   } else {
-                    Column(modifier = Modifier.fillMaxWidth().fillMaxHeight()) {
-                      SearchBar(
-                          value = searchBarState.query,
-                          onValueChange = searchBarState.onQueryChange,
-                          isSearchMode = isSearchMode,
-                          onTap = searchBarState.onTap,
-                          focusRequester = focusRequester,
-                          onSearchAction = {
-                            searchBarState.onSubmit()
-                            focusManager.clearFocus()
-                          },
-                          onClear = searchBarState.onClear,
-                          avatarUrl = avatarUrl ?: userProfile.avatarUrl,
-                          onProfileClick = { showProfileMenu = true })
+                    val density = LocalDensity.current
+                    val imeVisible = WindowInsets.isImeVisible
+                    val imeBottom = if (imeVisible) WindowInsets.ime.getBottom(density) else 0
+                    val imeHeightDp = with(density) { imeBottom.toDp() }
 
-                      Spacer(modifier = Modifier.height(24.dp))
+                    Column(
+                        modifier =
+                            Modifier.fillMaxWidth().fillMaxHeight().padding(bottom = imeHeightDp)) {
+                          SearchBar(
+                              value = searchBarState.query,
+                              onValueChange = searchBarState.onQueryChange,
+                              isSearchMode = isSearchMode,
+                              onTap = searchBarState.onTap,
+                              focusRequester = focusRequester,
+                              onSearchAction = {
+                                searchBarState.onSubmit()
+                                focusManager.clearFocus()
+                              },
+                              onClear = searchBarState.onClear,
+                              avatarUrl = avatarUrl ?: userProfile.avatarUrl,
+                              onProfileClick = { showProfileMenu = true })
 
-                      AnimatedContent(
-                          targetState = isSearchMode,
-                          transitionSpec = {
-                            (fadeIn(animationSpec = tween(TRANSITION_FADE_IN_DURATION_MS)) +
-                                    slideInVertically(
-                                        animationSpec = tween(TRANSITION_FADE_IN_DURATION_MS),
-                                        initialOffsetY = { it / TRANSITION_SLIDE_OFFSET_DIVISOR }))
-                                .togetherWith(
-                                    fadeOut(
-                                        animationSpec = tween(TRANSITION_FADE_OUT_DURATION_MS)) +
-                                        slideOutVertically(
-                                            animationSpec = tween(TRANSITION_FADE_OUT_DURATION_MS),
-                                            targetOffsetY = {
+                          Spacer(modifier = Modifier.height(24.dp))
+
+                          AnimatedContent(
+                              targetState = isSearchMode,
+                              transitionSpec = {
+                                (fadeIn(animationSpec = tween(TRANSITION_FADE_IN_DURATION_MS)) +
+                                        slideInVertically(
+                                            animationSpec = tween(TRANSITION_FADE_IN_DURATION_MS),
+                                            initialOffsetY = {
                                               it / TRANSITION_SLIDE_OFFSET_DIVISOR
                                             }))
-                          },
-                          modifier = Modifier.fillMaxWidth().weight(1f, fill = true),
-                          label = "searchModeTransition") { searchActive ->
-                            if (searchActive) {
-                              SearchResultsSection(
-                                  modifier = Modifier.fillMaxSize(),
-                                  results = searchResults,
-                                  query = searchBarState.query,
-                                  recentItems = recentItems,
-                                  onRecentSearchClick = onRecentSearchClick,
-                                  onRecentEventClick = onRecentEventClick,
-                                  onShowAllRecents = { showAllRecents = true },
-                                  onEventClick = onEventClick)
-                            } else {
-                              val density = LocalDensity.current
-                              val imeBottom = WindowInsets.ime.getBottom(density)
-                              val imePaddingModifier =
-                                  if (imeBottom > 0) {
-                                    Modifier.padding(bottom = with(density) { imeBottom.toDp() })
-                                  } else {
-                                    Modifier
-                                  }
-                              val contentModifier =
-                                  if (isFull)
-                                      Modifier.fillMaxWidth()
-                                          .then(imePaddingModifier)
-                                          .verticalScroll(scrollState)
-                                  else Modifier.fillMaxWidth()
+                                    .togetherWith(
+                                        fadeOut(
+                                            animationSpec =
+                                                tween(TRANSITION_FADE_OUT_DURATION_MS)) +
+                                            slideOutVertically(
+                                                animationSpec =
+                                                    tween(TRANSITION_FADE_OUT_DURATION_MS),
+                                                targetOffsetY = {
+                                                  it / TRANSITION_SLIDE_OFFSET_DIVISOR
+                                                }))
+                              },
+                              modifier = Modifier.fillMaxWidth().weight(1f, fill = true),
+                              label = "searchModeTransition") { searchActive ->
+                                if (searchActive) {
+                                  SearchResultsSection(
+                                      modifier = Modifier.fillMaxSize(),
+                                      results = searchResults,
+                                      query = searchBarState.query,
+                                      recentItems = recentItems,
+                                      onRecentSearchClick = onRecentSearchClick,
+                                      onRecentEventClick = onRecentEventClick,
+                                      onShowAllRecents = { showAllRecents = true },
+                                      onEventClick = onEventClick)
+                                } else {
+                                  val density = LocalDensity.current
+                                  val imeBottom = WindowInsets.ime.getBottom(density)
+                                  val imePaddingModifier =
+                                      if (imeBottom > 0) {
+                                        Modifier.padding(
+                                            bottom = with(density) { imeBottom.toDp() })
+                                      } else {
+                                        Modifier
+                                      }
+                                  val contentModifier =
+                                      if (isFull)
+                                          Modifier.fillMaxWidth()
+                                              .then(imePaddingModifier)
+                                              .verticalScroll(scrollState)
+                                      else Modifier.fillMaxWidth()
 
-                              Column(modifier = contentModifier) {
-                                // HorizontalDivider(color = Color.Gray.copy(alpha = 0.15f))
-                                Spacer(modifier = Modifier.height(19.dp))
+                                  Column(modifier = contentModifier) {
+                                    Spacer(modifier = Modifier.height(19.dp))
 
-                                CreateEventSection(onCreateEventClick = onCreateEventClick)
+                                    CreateEventSection(onCreateEventClick = onCreateEventClick)
 
-                                Spacer(modifier = Modifier.height(19.dp))
-                                Spacer(modifier = Modifier.height(16.dp))
+                                    Spacer(modifier = Modifier.height(19.dp))
+                                    Spacer(modifier = Modifier.height(16.dp))
 
-                                Text(
-                                    text = "My Events",
-                                    textAlign = TextAlign.Center,
-                                    style = MaterialTheme.typography.titleMedium,
-                                    modifier = Modifier.padding(bottom = 12.dp))
-                                // Tabs
-                                TabRow(
-                                    selectedTabIndex = selectedTab.ordinal,
-                                    modifier = Modifier.fillMaxWidth()) {
-                                      Tab(
-                                          selected =
-                                              selectedTab ==
-                                                  MapScreenViewModel.BottomSheetTab.SAVED,
-                                          onClick = {
-                                            onTabChange(MapScreenViewModel.BottomSheetTab.SAVED)
-                                          },
-                                          text = {
-                                            Text(
-                                                text = "Saved",
-                                                maxLines = 1,
-                                                softWrap = false,
-                                                overflow = TextOverflow.Ellipsis)
-                                          })
-                                      Tab(
-                                          selected =
-                                              selectedTab ==
-                                                  MapScreenViewModel.BottomSheetTab.UPCOMING,
-                                          onClick = {
-                                            onTabChange(MapScreenViewModel.BottomSheetTab.UPCOMING)
-                                          },
-                                          text = {
-                                            Text(
-                                                text = "Upcoming",
-                                                maxLines = 1,
-                                                softWrap = false,
-                                                overflow = TextOverflow.Ellipsis)
-                                          })
-                                      Tab(
-                                          selected =
-                                              selectedTab == MapScreenViewModel.BottomSheetTab.PAST,
-                                          onClick = {
-                                            onTabChange(MapScreenViewModel.BottomSheetTab.PAST)
-                                          },
-                                          text = {
-                                            Text(
-                                                text = "Past",
-                                                maxLines = 1,
-                                                softWrap = false,
-                                                overflow = TextOverflow.Ellipsis)
-                                          })
-                                      Tab(
-                                          selected =
-                                              selectedTab ==
-                                                  MapScreenViewModel.BottomSheetTab.OWNED,
-                                          onClick = {
-                                            onTabChange(MapScreenViewModel.BottomSheetTab.OWNED)
-                                          },
-                                          text = {
-                                            Text(
-                                                text = "Owned",
-                                                maxLines = 1,
-                                                softWrap = false,
-                                                overflow = TextOverflow.Ellipsis)
-                                          })
+                                    Text(
+                                        text = "My Events",
+                                        textAlign = TextAlign.Center,
+                                        style = MaterialTheme.typography.titleMedium,
+                                        modifier = Modifier.padding(bottom = 12.dp))
+                                    // Tabs
+                                    TabRow(
+                                        selectedTabIndex = selectedTab.ordinal,
+                                        modifier = Modifier.fillMaxWidth()) {
+                                          Tab(
+                                              selected =
+                                                  selectedTab ==
+                                                      MapScreenViewModel.BottomSheetTab.SAVED,
+                                              onClick = {
+                                                onTabChange(MapScreenViewModel.BottomSheetTab.SAVED)
+                                              },
+                                              text = {
+                                                Text(
+                                                    text = "Saved",
+                                                    maxLines = 1,
+                                                    softWrap = false,
+                                                    overflow = TextOverflow.Ellipsis)
+                                              })
+                                          Tab(
+                                              selected =
+                                                  selectedTab ==
+                                                      MapScreenViewModel.BottomSheetTab.UPCOMING,
+                                              onClick = {
+                                                onTabChange(
+                                                    MapScreenViewModel.BottomSheetTab.UPCOMING)
+                                              },
+                                              text = {
+                                                Text(
+                                                    text = "Upcoming",
+                                                    maxLines = 1,
+                                                    softWrap = false,
+                                                    overflow = TextOverflow.Ellipsis)
+                                              })
+                                          Tab(
+                                              selected =
+                                                  selectedTab ==
+                                                      MapScreenViewModel.BottomSheetTab.PAST,
+                                              onClick = {
+                                                onTabChange(MapScreenViewModel.BottomSheetTab.PAST)
+                                              },
+                                              text = {
+                                                Text(
+                                                    text = "Past",
+                                                    maxLines = 1,
+                                                    softWrap = false,
+                                                    overflow = TextOverflow.Ellipsis)
+                                              })
+                                          Tab(
+                                              selected =
+                                                  selectedTab ==
+                                                      MapScreenViewModel.BottomSheetTab.OWNED,
+                                              onClick = {
+                                                onTabChange(MapScreenViewModel.BottomSheetTab.OWNED)
+                                              },
+                                              text = {
+                                                Text(
+                                                    text = "Owned",
+                                                    maxLines = 1,
+                                                    softWrap = false,
+                                                    overflow = TextOverflow.Ellipsis)
+                                              })
+                                        }
+                                    Spacer(modifier = Modifier.height(16.dp))
+
+                                    when (selectedTab) {
+                                      MapScreenViewModel.BottomSheetTab.SAVED -> {
+                                        SavedEventsSection(
+                                            savedEvents = savedEvents,
+                                            onEventClick = onTabEventClick)
+                                      }
+                                      MapScreenViewModel.BottomSheetTab.UPCOMING -> {
+                                        UpcomingEventsSection(
+                                            upcomingEvents = joinedEvents,
+                                            onEventClick = onTabEventClick)
+                                      }
+                                      MapScreenViewModel.BottomSheetTab.PAST -> {
+                                        AttendedEventsSection(
+                                            attendedEvents = attendedEvents,
+                                            onEventClick = onEventClick,
+                                            onCreateMemoryClick = onCreateMemoryClick)
+                                      }
+                                      MapScreenViewModel.BottomSheetTab.OWNED -> {
+                                        OwnedEventsSection(
+                                            events = ownedEvents,
+                                            loading = ownedLoading,
+                                            error = ownedError,
+                                            onEventClick = onTabEventClick,
+                                            onEditEvent = onEditEvent,
+                                            onDeleteEvent = onDeleteEvent,
+                                            onRetry = onRetryOwnedEvents)
+                                      }
                                     }
-                                Spacer(modifier = Modifier.height(16.dp))
 
-                                when (selectedTab) {
-                                  MapScreenViewModel.BottomSheetTab.SAVED -> {
-                                    SavedEventsSection(
-                                        savedEvents = savedEvents, onEventClick = onTabEventClick)
-                                  }
-                                  MapScreenViewModel.BottomSheetTab.UPCOMING -> {
-                                    UpcomingEventsSection(
-                                        upcomingEvents = joinedEvents,
-                                        onEventClick = onTabEventClick)
-                                  }
-                                  MapScreenViewModel.BottomSheetTab.PAST -> {
-                                    AttendedEventsSection(
-                                        attendedEvents = attendedEvents,
-                                        onEventClick = onEventClick,
-                                        onCreateMemoryClick = onCreateMemoryClick)
-                                  }
-                                  MapScreenViewModel.BottomSheetTab.OWNED -> {
-                                    OwnedEventsSection(
-                                        events = ownedEvents,
-                                        loading = ownedLoading,
-                                        error = ownedError,
-                                        onEventClick = onTabEventClick,
-                                        onEditEvent = onEditEvent,
-                                        onDeleteEvent = onDeleteEvent,
-                                        onRetry = onRetryOwnedEvents)
+                                    Spacer(modifier = Modifier.height(12.dp))
+
+                                    // Filters section visible unless collapsed
+                                    if (state != BottomSheetState.COLLAPSED) {
+                                      filterSection.Render(
+                                          Modifier.fillMaxWidth(),
+                                          filterViewModel,
+                                          locationViewModel,
+                                          userProfile)
+
+                                      Spacer(modifier = Modifier.height(16.dp))
+                                    }
+
+                                    Spacer(modifier = Modifier.height(24.dp))
                                   }
                                 }
-
-                                Spacer(modifier = Modifier.height(12.dp))
-
-                                // Filters section visible unless collapsed
-                                if (state != BottomSheetState.COLLAPSED) {
-                                  filterSection.Render(
-                                      Modifier.fillMaxWidth(),
-                                      filterViewModel,
-                                      locationViewModel,
-                                      userProfile)
-
-                                  Spacer(modifier = Modifier.height(16.dp))
-                                }
-
-                                Spacer(modifier = Modifier.height(24.dp))
                               }
-                            }
-                          }
-                    }
+                        }
                   }
                 }
 


### PR DESCRIPTION
## Description

Fixes the persistent white block that appears at the bottom of the bottom sheet when the keyboard is dismissed. The issue occurred because the IME (Input Method Editor) insets were not properly cleared when the keyboard was hidden, causing a padding artifact.

**Related Issue:** Closes #432. Note: this issue was thought to be fixed in a previous PR, but a new bug appeared. So this PR updates this.

---

## Changes


The large diff is because we  refactored the IME padding logic and moved it up in the component  hierarchy, which caused ktfmtFormat to reformat the entire nested  structure.

**The core change is** 


We added an import : 

``` kotlin
import androidx.compose.foundation.layout.isImeVisible
```

We added the IME detection and padding calculation (4 lines): 

``` kotlin 
val density = LocalDensity.current
val imeVisible = WindowInsets.isImeVisible
val imeBottom = if (imeVisible) WindowInsets.ime.getBottom(density) else 0
val imeHeightDp = with(density) { imeBottom.toDp() }
```

We modified Column modifier

``` kotlin 
  - Column(modifier = Modifier.fillMaxWidth().fillMaxHeight()) {
  + Column(modifier = Modifier.fillMaxWidth().fillMaxHeight().padding(bottom= imeHeightDp)) {
```

That's it. Everything else is ktfmt reformatting the indentation because of the structural change. 




**Implementation:**
- Added `WindowInsets.isImeVisible` check to properly detect keyboard visibility state
- Applied IME-aware padding at the outer Column level that wraps search bar and content
- Padding is dynamically calculated based on IME bottom inset only when keyboard is actually visible
- When keyboard is dismissed (`isImeVisible == false`), padding is set to 0
**Tests:**
- Manual testing completed with multiple reproduction scenarios
- Verified fix works for: search bar focus/dismiss, state transitions, and profile sheet navigation

---

## Testing
- [x] Unit tests pass
- [x] Instrumentation tests pass
- [x] Manual testing completed
- [x] Coverage maintained (≥80%)
**Test summary:** Manually tested 4 different reproduction scenarios that previously triggered the bug. All scenarios now work correctly without white block appearing.


**Reproduction scenarios tested:**
1. Search bar focus → keyboard dismiss → sheet state transitions
2. Profile sheet after search (keyboard dismiss)
3. Quick state transitions (FULL → MEDIUM → FULL)
4. Search → submit → reopen search

---

## Screenshots/Videos
The white block issue was visible when transitioning between bottom sheet states after dismissing the keyboard. After this fix, the bottom sheet properly resizes without leaving white space.

---

## Checklist
- [x] Sufficient documentation and minimal inline comments
- [x] All tests passing
- [x] No new warnings
- [x] If related issue exists: issue has all labels, fields, and milestone filled