### PR TITLE
Re-enable CI on main branch for SonarCloud analysis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,10 @@
 name: CI - Test Runner
 
-# Run the workflow when a PR is modified
+# Run the workflow when a PR is modified or when code is pushed to main
 on:
+  push:
+    branches:
+      - main
   pull_request:
     types:
       - opened


### PR DESCRIPTION
## Description
Re-enable CI workflow on pushes to the main branch to ensure SonarCloud can analyze and track code quality metrics for the main branch.

Previously, the push trigger was removed in commit 5fecabd, which caused SonarCloud to stop analyzing the main branch after PR merges. This resulted in outdated coverage reports and quality metrics.

**Related Issue:** N/A (infrastructure fix)

---

## Changes

**Implementation:**
- Added `push` trigger to CI workflow scoped to `main` branch only
- Maintains existing `pull_request` triggers for PR analysis
- No duplicate runs: PRs analyzed on PR events, main analyzed on merge

**Tests:**
- No test changes needed (infrastructure only)

---

## Testing
- [x] Unit tests pass (no changes)
- [x] Instrumentation tests pass (no changes)
- [x] Manual testing completed (verified workflow syntax)
- [x] Coverage maintained (≥80%) (no code changes)

**Test summary:** Infrastructure change only - CI workflow will run on next push to main

---

## Checklist
- [x] Sufficient documentation and minimal inline comments
- [x] All tests passing
- [x] No new warnings
- [x] If related issue exists: issue has all labels, fields, and milestone filled

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>