### PR TITLE
Fix search bar content jumping above search bar on focus

### DIFF
--- a/app/src/main/java/com/swent/mapin/ui/map/BottomSheetContent.kt
+++ b/app/src/main/java/com/swent/mapin/ui/map/BottomSheetContent.kt
@@ -21,7 +21,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.ime
-import androidx.compose.foundation.layout.isImeVisible
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -312,207 +311,185 @@ fun BottomSheetContent(
                         },
                         onBack = { showAllRecents = false })
                   } else {
-                    val density = LocalDensity.current
-                    val imeVisible = WindowInsets.isImeVisible
-                    val imeBottom = if (imeVisible) WindowInsets.ime.getBottom(density) else 0
-                    val imeHeightDp = with(density) { imeBottom.toDp() }
+                    Column(modifier = Modifier.fillMaxWidth().fillMaxHeight()) {
+                      SearchBar(
+                          value = searchBarState.query,
+                          onValueChange = searchBarState.onQueryChange,
+                          isSearchMode = isSearchMode,
+                          onTap = searchBarState.onTap,
+                          focusRequester = focusRequester,
+                          onSearchAction = {
+                            searchBarState.onSubmit()
+                            focusManager.clearFocus()
+                          },
+                          onClear = searchBarState.onClear,
+                          avatarUrl = avatarUrl ?: userProfile.avatarUrl,
+                          onProfileClick = { showProfileMenu = true })
 
-                    Column(
-                        modifier =
-                            Modifier.fillMaxWidth().fillMaxHeight().padding(bottom = imeHeightDp)) {
-                          SearchBar(
-                              value = searchBarState.query,
-                              onValueChange = searchBarState.onQueryChange,
-                              isSearchMode = isSearchMode,
-                              onTap = searchBarState.onTap,
-                              focusRequester = focusRequester,
-                              onSearchAction = {
-                                searchBarState.onSubmit()
-                                focusManager.clearFocus()
-                              },
-                              onClear = searchBarState.onClear,
-                              avatarUrl = avatarUrl ?: userProfile.avatarUrl,
-                              onProfileClick = { showProfileMenu = true })
+                      Spacer(modifier = Modifier.height(24.dp))
 
-                          Spacer(modifier = Modifier.height(24.dp))
+                      AnimatedContent(
+                          targetState = isSearchMode,
+                          transitionSpec = {
+                            fadeIn(animationSpec = tween(TRANSITION_FADE_IN_DURATION_MS))
+                                .togetherWith(
+                                    fadeOut(animationSpec = tween(TRANSITION_FADE_OUT_DURATION_MS)))
+                          },
+                          modifier = Modifier.fillMaxWidth().weight(1f, fill = true),
+                          label = "searchModeTransition") { searchActive ->
+                            val density = LocalDensity.current
+                            val imeBottom = WindowInsets.ime.getBottom(density)
+                            val imePaddingDp = with(density) { imeBottom.toDp() }
 
-                          AnimatedContent(
-                              targetState = isSearchMode,
-                              transitionSpec = {
-                                (fadeIn(animationSpec = tween(TRANSITION_FADE_IN_DURATION_MS)) +
-                                        slideInVertically(
-                                            animationSpec = tween(TRANSITION_FADE_IN_DURATION_MS),
-                                            initialOffsetY = {
-                                              it / TRANSITION_SLIDE_OFFSET_DIVISOR
-                                            }))
-                                    .togetherWith(
-                                        fadeOut(
-                                            animationSpec =
-                                                tween(TRANSITION_FADE_OUT_DURATION_MS)) +
-                                            slideOutVertically(
-                                                animationSpec =
-                                                    tween(TRANSITION_FADE_OUT_DURATION_MS),
-                                                targetOffsetY = {
-                                                  it / TRANSITION_SLIDE_OFFSET_DIVISOR
-                                                }))
-                              },
-                              modifier = Modifier.fillMaxWidth().weight(1f, fill = true),
-                              label = "searchModeTransition") { searchActive ->
-                                if (searchActive) {
-                                  SearchResultsSection(
-                                      modifier = Modifier.fillMaxSize(),
-                                      results = searchResults,
-                                      query = searchBarState.query,
-                                      recentItems = recentItems,
-                                      onRecentSearchClick = onRecentSearchClick,
-                                      onRecentEventClick = onRecentEventClick,
-                                      onRecentProfileClick = onRecentProfileClick,
-                                      onShowAllRecents = { showAllRecents = true },
-                                      onEventClick = onEventClick,
-                                      sheetState = state,
-                                      userResults = userSearchResults,
-                                      onUserClick = onUserSearchClick)
-                                } else {
-                                  val density = LocalDensity.current
-                                  val imeBottom = WindowInsets.ime.getBottom(density)
-                                  val imePaddingModifier =
-                                      if (imeBottom > 0) {
-                                        Modifier.padding(
-                                            bottom = with(density) { imeBottom.toDp() })
-                                      } else {
-                                        Modifier
-                                      }
-                                  val contentModifier =
-                                      if (isFull)
-                                          Modifier.fillMaxWidth()
-                                              .then(imePaddingModifier)
-                                              .verticalScroll(scrollState)
-                                      else Modifier.fillMaxWidth()
+                            if (searchActive) {
+                              SearchResultsSection(
+                                  modifier = Modifier.fillMaxSize().padding(bottom = imePaddingDp),
+                                  results = searchResults,
+                                  query = searchBarState.query,
+                                  recentItems = recentItems,
+                                  onRecentSearchClick = onRecentSearchClick,
+                                  onRecentEventClick = onRecentEventClick,
+                                  onRecentProfileClick = onRecentProfileClick,
+                                  onShowAllRecents = { showAllRecents = true },
+                                  onEventClick = onEventClick,
+                                  sheetState = state,
+                                  userResults = userSearchResults,
+                                  onUserClick = onUserSearchClick)
+                            } else {
+                              val imePaddingModifier =
+                                  if (imeBottom > 0) {
+                                    Modifier.padding(bottom = imePaddingDp)
+                                  } else {
+                                    Modifier
+                                  }
+                              val contentModifier =
+                                  if (isFull)
+                                      Modifier.fillMaxWidth()
+                                          .then(imePaddingModifier)
+                                          .verticalScroll(scrollState)
+                                  else Modifier.fillMaxWidth()
 
-                                  Column(modifier = contentModifier) {
-                                    Spacer(modifier = Modifier.height(19.dp))
+                              Column(modifier = contentModifier) {
+                                Spacer(modifier = Modifier.height(19.dp))
 
-                                    CreateEventSection(onCreateEventClick = onCreateEventClick)
+                                CreateEventSection(onCreateEventClick = onCreateEventClick)
 
-                                    Spacer(modifier = Modifier.height(19.dp))
-                                    Spacer(modifier = Modifier.height(16.dp))
+                                Spacer(modifier = Modifier.height(19.dp))
+                                Spacer(modifier = Modifier.height(16.dp))
 
-                                    Text(
-                                        text = "My Events",
-                                        textAlign = TextAlign.Center,
-                                        style = MaterialTheme.typography.titleMedium,
-                                        modifier = Modifier.padding(bottom = 12.dp))
-                                    // Tabs
-                                    TabRow(
-                                        selectedTabIndex = selectedTab.ordinal,
-                                        modifier = Modifier.fillMaxWidth()) {
-                                          Tab(
-                                              selected =
-                                                  selectedTab ==
-                                                      MapScreenViewModel.BottomSheetTab.SAVED,
-                                              onClick = {
-                                                onTabChange(MapScreenViewModel.BottomSheetTab.SAVED)
-                                              },
-                                              text = {
-                                                Text(
-                                                    text = "Saved",
-                                                    maxLines = 1,
-                                                    softWrap = false,
-                                                    overflow = TextOverflow.Ellipsis)
-                                              })
-                                          Tab(
-                                              selected =
-                                                  selectedTab ==
-                                                      MapScreenViewModel.BottomSheetTab.UPCOMING,
-                                              onClick = {
-                                                onTabChange(
-                                                    MapScreenViewModel.BottomSheetTab.UPCOMING)
-                                              },
-                                              text = {
-                                                Text(
-                                                    text = "Upcoming",
-                                                    maxLines = 1,
-                                                    softWrap = false,
-                                                    overflow = TextOverflow.Ellipsis)
-                                              })
-                                          Tab(
-                                              selected =
-                                                  selectedTab ==
-                                                      MapScreenViewModel.BottomSheetTab.PAST,
-                                              onClick = {
-                                                onTabChange(MapScreenViewModel.BottomSheetTab.PAST)
-                                              },
-                                              text = {
-                                                Text(
-                                                    text = "Past",
-                                                    maxLines = 1,
-                                                    softWrap = false,
-                                                    overflow = TextOverflow.Ellipsis)
-                                              })
-                                          Tab(
-                                              selected =
-                                                  selectedTab ==
-                                                      MapScreenViewModel.BottomSheetTab.OWNED,
-                                              onClick = {
-                                                onTabChange(MapScreenViewModel.BottomSheetTab.OWNED)
-                                              },
-                                              text = {
-                                                Text(
-                                                    text = "Owned",
-                                                    maxLines = 1,
-                                                    softWrap = false,
-                                                    overflow = TextOverflow.Ellipsis)
-                                              })
-                                        }
-                                    Spacer(modifier = Modifier.height(16.dp))
-
-                                    when (selectedTab) {
-                                      MapScreenViewModel.BottomSheetTab.SAVED -> {
-                                        SavedEventsSection(
-                                            savedEvents = savedEvents,
-                                            onEventClick = onTabEventClick)
-                                      }
-                                      MapScreenViewModel.BottomSheetTab.UPCOMING -> {
-                                        UpcomingEventsSection(
-                                            upcomingEvents = joinedEvents,
-                                            onEventClick = onTabEventClick)
-                                      }
-                                      MapScreenViewModel.BottomSheetTab.PAST -> {
-                                        AttendedEventsSection(
-                                            attendedEvents = attendedEvents,
-                                            onEventClick = onEventClick,
-                                            onCreateMemoryClick = onCreateMemoryClick)
-                                      }
-                                      MapScreenViewModel.BottomSheetTab.OWNED -> {
-                                        OwnedEventsSection(
-                                            events = ownedEvents,
-                                            loading = ownedLoading,
-                                            error = ownedError,
-                                            onEventClick = onTabEventClick,
-                                            onEditEvent = onEditEvent,
-                                            onDeleteEvent = onDeleteEvent,
-                                            onRetry = onRetryOwnedEvents)
-                                      }
+                                Text(
+                                    text = "My Events",
+                                    textAlign = TextAlign.Center,
+                                    style = MaterialTheme.typography.titleMedium,
+                                    modifier = Modifier.padding(bottom = 12.dp))
+                                // Tabs
+                                TabRow(
+                                    selectedTabIndex = selectedTab.ordinal,
+                                    modifier = Modifier.fillMaxWidth()) {
+                                      Tab(
+                                          selected =
+                                              selectedTab ==
+                                                  MapScreenViewModel.BottomSheetTab.SAVED,
+                                          onClick = {
+                                            onTabChange(MapScreenViewModel.BottomSheetTab.SAVED)
+                                          },
+                                          text = {
+                                            Text(
+                                                text = "Saved",
+                                                maxLines = 1,
+                                                softWrap = false,
+                                                overflow = TextOverflow.Ellipsis)
+                                          })
+                                      Tab(
+                                          selected =
+                                              selectedTab ==
+                                                  MapScreenViewModel.BottomSheetTab.UPCOMING,
+                                          onClick = {
+                                            onTabChange(MapScreenViewModel.BottomSheetTab.UPCOMING)
+                                          },
+                                          text = {
+                                            Text(
+                                                text = "Upcoming",
+                                                maxLines = 1,
+                                                softWrap = false,
+                                                overflow = TextOverflow.Ellipsis)
+                                          })
+                                      Tab(
+                                          selected =
+                                              selectedTab == MapScreenViewModel.BottomSheetTab.PAST,
+                                          onClick = {
+                                            onTabChange(MapScreenViewModel.BottomSheetTab.PAST)
+                                          },
+                                          text = {
+                                            Text(
+                                                text = "Past",
+                                                maxLines = 1,
+                                                softWrap = false,
+                                                overflow = TextOverflow.Ellipsis)
+                                          })
+                                      Tab(
+                                          selected =
+                                              selectedTab ==
+                                                  MapScreenViewModel.BottomSheetTab.OWNED,
+                                          onClick = {
+                                            onTabChange(MapScreenViewModel.BottomSheetTab.OWNED)
+                                          },
+                                          text = {
+                                            Text(
+                                                text = "Owned",
+                                                maxLines = 1,
+                                                softWrap = false,
+                                                overflow = TextOverflow.Ellipsis)
+                                          })
                                     }
+                                Spacer(modifier = Modifier.height(16.dp))
 
-                                    Spacer(modifier = Modifier.height(12.dp))
-
-                                    // Filters section visible unless collapsed
-                                    if (state != BottomSheetState.COLLAPSED) {
-                                      filterSection.Render(
-                                          Modifier.fillMaxWidth(),
-                                          filterViewModel,
-                                          locationViewModel,
-                                          userProfile)
-
-                                      Spacer(modifier = Modifier.height(16.dp))
-                                    }
-
-                                    Spacer(modifier = Modifier.height(24.dp))
+                                when (selectedTab) {
+                                  MapScreenViewModel.BottomSheetTab.SAVED -> {
+                                    SavedEventsSection(
+                                        savedEvents = savedEvents, onEventClick = onTabEventClick)
+                                  }
+                                  MapScreenViewModel.BottomSheetTab.UPCOMING -> {
+                                    UpcomingEventsSection(
+                                        upcomingEvents = joinedEvents,
+                                        onEventClick = onTabEventClick)
+                                  }
+                                  MapScreenViewModel.BottomSheetTab.PAST -> {
+                                    AttendedEventsSection(
+                                        attendedEvents = attendedEvents,
+                                        onEventClick = onEventClick,
+                                        onCreateMemoryClick = onCreateMemoryClick)
+                                  }
+                                  MapScreenViewModel.BottomSheetTab.OWNED -> {
+                                    OwnedEventsSection(
+                                        events = ownedEvents,
+                                        loading = ownedLoading,
+                                        error = ownedError,
+                                        onEventClick = onTabEventClick,
+                                        onEditEvent = onEditEvent,
+                                        onDeleteEvent = onDeleteEvent,
+                                        onRetry = onRetryOwnedEvents)
                                   }
                                 }
+
+                                Spacer(modifier = Modifier.height(12.dp))
+
+                                // Filters section visible unless collapsed
+                                if (state != BottomSheetState.COLLAPSED) {
+                                  filterSection.Render(
+                                      Modifier.fillMaxWidth(),
+                                      filterViewModel,
+                                      locationViewModel,
+                                      userProfile)
+
+                                  Spacer(modifier = Modifier.height(16.dp))
+                                }
+
+                                Spacer(modifier = Modifier.height(24.dp))
                               }
-                        }
+                            }
+                          }
+                    }
                   }
                 }
 


### PR DESCRIPTION
## Description
Fix UI bug where recent searches content jumps above the search bar when clicking the search bar, especially when transitioning from FULL bottom sheet mode.

**Related Issue:** Closes #459

---

## Changes

**Implementation:**

- Removed `slideInVertically` and `slideOutVertically` animations from `searchModeTransition` - these caused the content to overshoot when combined with layout changes
- Moved IME padding calculation inside the `AnimatedContent` lambda (shared by both branches) instead of on the outer Column
- Added IME padding to `SearchResultsSection` to maintain the white block fix from #451

**Tests:**

- No new tests required - this is a visual animation fix
- Existing tests should pass as no API changes were made

---

## Testing
- [ ] Unit tests pass
- [ ] Instrumentation tests pass
- [x] Manual testing completed
- [ ] Coverage maintained (≥80%)

**Test summary:** Manually verified that:
1. Content no longer jumps above search bar when clicking it
2. No white block appears when keyboard is dismissed (regression test for #451)

---

## Checklist
- [x] Sufficient documentation and minimal inline comments
- [ ] All tests passing
- [x] No new warnings
- [x] If related issue exists: issue has all labels, fields, and milestone filled

---

## Note for Reviewers

The diff appears large due to indentation changes (the code moved from being inside a Column with IME padding to a simpler Column), but the **actual functional changes are minimal**:
1. Removed unused `isImeVisible` import
2. Removed IME padding from outer Column
3. Changed `searchModeTransition` from `fadeIn + slideInVertically` to just `fadeIn`
4.  Moved IME padding calculation inside AnimatedContent
5. Added `.padding(bottom = imePaddingDp)` to SearchResultsSection

Everything else is just re-indentation due to the nesting level change.