### PR TITLE
Update README and add release workflow

### DIFF
--- a/.github/workflows/release-apk.yml
+++ b/.github/workflows/release-apk.yml
@@ -1,0 +1,99 @@
+name: Release APK
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-release:
+    name: Build & Publish Release APK
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Setup JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "17"
+
+      - name: Gradle cache
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Restore release keystore
+        env:
+          RELEASE_KEYSTORE_B64: ${{ secrets.RELEASE_KEYSTORE_B64 }}
+          RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
+          RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
+          RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
+        run: |
+          if [ -z "$RELEASE_KEYSTORE_B64" ] || [ -z "$RELEASE_KEYSTORE_PASSWORD" ] || [ -z "$RELEASE_KEY_ALIAS" ] || [ -z "$RELEASE_KEY_PASSWORD" ]; then
+            echo "Release keystore secrets are not configured." >&2
+            exit 1
+          fi
+          mkdir -p android/keystores
+          echo "$RELEASE_KEYSTORE_B64" | base64 --decode > android/keystores/release.keystore
+
+      - name: Restore google-services.json
+        env:
+          FIREBASE_SERVICE_JSON_B64: ${{ secrets.FIREBASE_SERVICE_JSON_B64 }}
+        run: |
+          if [ -z "$FIREBASE_SERVICE_JSON_B64" ]; then
+            echo "FIREBASE_SERVICE_JSON_B64 secret is not set." >&2
+            exit 1
+          fi
+          mkdir -p app
+          echo "$FIREBASE_SERVICE_JSON_B64" | base64 --decode > app/google-services.json
+
+      - name: Restore Mapbox access token resource
+        env:
+          MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
+        run: |
+          if [ -z "$MAPBOX_ACCESS_TOKEN" ]; then
+            echo "MAPBOX_ACCESS_TOKEN secret is not set." >&2
+            exit 1
+          fi
+          mkdir -p app/src/main/res/values
+          cat <<EOF > app/src/main/res/values/mapbox_access_token.xml
+          <?xml version="1.0" encoding="utf-8"?>
+          <resources xmlns:tools="http://schemas.android.com/tools">
+              <string name="mapbox_access_token" translatable="false" tools:ignore="UnusedResources">$MAPBOX_ACCESS_TOKEN</string>
+          </resources>
+          EOF
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+
+      - name: Build signed Release APK
+        env:
+          RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
+          RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
+          RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
+        run: |
+          ./gradlew assembleRelease \
+            -Pandroid.injected.signing.store.file=$PWD/android/keystores/release.keystore \
+            -Pandroid.injected.signing.store.password="$RELEASE_KEYSTORE_PASSWORD" \
+            -Pandroid.injected.signing.key.alias="$RELEASE_KEY_ALIAS" \
+            -Pandroid.injected.signing.key.password="$RELEASE_KEY_PASSWORD"
+
+      - name: Create GitHub Release
+        id: create_release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: Release ${{ github.ref_name }}
+          draft: false
+          prerelease: false
+          generate_release_notes: true
+          files: app/build/outputs/apk/release/*.apk
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,15 +1,42 @@
-# Map’In
+# Map'In
 
-## App Description
+Your campus in one glance. Map'In is the social map that helps students discover what's happening nearby, jump into events with friends, and relive the best moments — guided by an AI that knows what you'll love.
 
-Map’In is a social map for students that brings events and memories together in one place.  
-The core experience is simple:  
+## Contents
+- [Features](#features)
+- [How It Works](#how-it-works)
+- [Install the App](#install-the-app)
+- [Screenshots & Demo](#screenshots--demo)
+- [Tech Highlights](#tech-highlights)
+- [License](#license)
 
-- **Create events** and share them with others  
-- **Join events** organized by friends, associations, or the community  
-- **Add memories** (media in general) once the event is over  
-- **View everything on an interactive map**, combining past and upcoming activities  
+## Features
+- Map-first discovery with filters for time, price, tags, and friends' plans
+- Create and share events in seconds, complete with reminders and invites
+- AI assistant that curates events you'll care about and guides you to the best options
+- Add memories (photos and media) so every event lives on
+- Group and one-to-one chat tied to events and friend circles
+- Smart notifications for invites, reminders, messages, and nearby friends
+- Privacy controls with biometric lock and theme preferences
 
-This way, students can not only discover and attend events, but also relive them afterwards through a collaborative map.  
+## How It Works
+1) Open the map to see what's happening now and what's coming up.  
+2) Tap an event to join, chat with attendees, and get directions.  
+3) After the event, drop photos and memories for everyone to enjoy.  
+4) Let the AI assistant surface the next plan that matches your vibe.  
 
-## Link of the Figma : [https://www.figma.com/design/1O4tdBFh8A6mPBKelmKLjo/Map-In?version-id=2275690016325390039&node-id=238-48&p=f&t=2B8ru3yUVYpRWBZv-0](https://www.figma.com/design/1O4tdBFh8A6mPBKelmKLjo/Map-In?node-id=415-64)
+## Install the App
+- Grab the latest Android APK from Releases and install (Android 9+ recommended).
+- Allow location for nearby picks and notifications for invites/reminders.
+- Sign in, set your preferences, and start exploring the map with friends.
+
+## Screenshots & Demo
+- SOON!
+
+## Tech Highlights
+- Android app built with Kotlin + Jetpack Compose
+- Mapbox-powered interactive map experience (Offline mode, light/dark mode, 3D view, satellite)
+- Firebase for auth, chat, events, notifications, and memories
+
+## License
+MIT License. See `LICENSE` for details.


### PR DESCRIPTION
  ## Description
  Make the README user-facing and add an automated tag-driven release workflow so APKs show up under Releases.

  **Related Issue:** <!-- Closes #123 or Related to #456 -->

  ---

  ## Changes

  **Implementation:**
  - Rewrite README to focus on using Map’In (features, flow, install steps, screenshots placeholder, tech highlights, license).
  - Add `Release APK` GitHub Action triggered by tags `v*` to build a signed release APK and attach it to a GitHub Release using existing secrets (keystore, Firebase, Mapbox).

  **Tests:**
  - Not run (docs/workflow change only).

  ---

  ## Testing
  - [ ] Unit tests pass
  - [ ] Instrumentation tests pass
  - [ ] Manual testing completed
  - [ ] Coverage maintained (≥80%)

  **Test summary:** Not run; configuration/docs-only changes.

  ---

  ## Screenshots/Videos
  N/A

  ---

  ## Checklist
  - [x] Sufficient documentation and minimal inline comments
  - [ ] All tests passing
  - [x] No new warnings
  - [ ] If related issue exists: issue has all labels, fields, and milestone filled
