### PR TITLE
fix: Resolve bug in EditEventScreen

### DIFF
--- a/app/src/main/java/com/swent/mapin/ui/event/EditEventScreen.kt
+++ b/app/src/main/java/com/swent/mapin/ui/event/EditEventScreen.kt
@@ -102,7 +102,7 @@ fun EditEventScreen(
   val isLoggedIn = remember { mutableStateOf((Firebase.auth.currentUser != null)) }
 
   val locationExpanded = remember { mutableStateOf(false) }
-  val gotLocation = remember { mutableStateOf(Location.UNDEFINED) }
+  val gotLocation = remember { mutableStateOf(event.location) }
   val locations by locationViewModel.locations.collectAsState()
 
   val scrollState = rememberScrollState()


### PR DESCRIPTION
Change gotLocation instantiation to resolve bug preventing saving edits when Location is not changed.

## Description
Fixed a bug where editing an event without changing its location would fail to save. The issue was caused by `gotLocation` being initialized to `Location.UNDEFINED` instead of the event's existing location value.

**Related Issue:**  #489 

---

## Changes

**Implementation:**
- Changed `gotLocation` initialization from `Location.UNDEFINED` to `event.location`

**Tests:**
- No new tests required (existing tests cover this scenario)

---

## Testing
- [x] Unit tests pass
- [x] Instrumentation tests pass
- [x] Manual testing completed
- [x] Coverage maintained (≥80%)

**Test summary:** Verified that editing an event without changing location now saves successfully.

---

## Screenshots/Videos
<!-- Not applicable for this bug fix -->

---

## Checklist
- [x] Sufficient documentation and minimal inline comments
- [x] All tests passing
- [x] No new warnings
- [x] If related issue exists: issue has all labels, fields, and milestone filled