### PR TITLE
Fix chat scroll button crash on empty conversations

### DIFF
--- a/app/src/main/java/com/swent/mapin/ui/chat/ConversationScreen.kt
+++ b/app/src/main/java/com/swent/mapin/ui/chat/ConversationScreen.kt
@@ -359,14 +359,16 @@ fun ConversationScreen(
                   MessageBubble(message, sender)
                 }
               }
-          // Button to scroll down to the newest message
-          IconButton(
-              onClick = {
-                coroutineScope.launch { listState.animateScrollToItem(messages.lastIndex) }
-              },
-              modifier = Modifier.align(Alignment.BottomEnd).padding(16.dp)) {
-                Icon(Icons.Filled.ArrowDownward, contentDescription = "Scroll to bottom")
-              }
+          // Button to scroll down to the newest message (only if there are messages)
+          if (messages.isNotEmpty()) {
+            IconButton(
+                onClick = {
+                  coroutineScope.launch { listState.animateScrollToItem(messages.lastIndex) }
+                },
+                modifier = Modifier.align(Alignment.BottomEnd).padding(16.dp)) {
+                  Icon(Icons.Filled.ArrowDownward, contentDescription = "Scroll to bottom")
+                }
+          }
         }
       }
 


### PR DESCRIPTION
## Description
Fix crash when tapping the scroll-down button on empty conversations by hiding the button when there are no messages.

**Related Issue:** Closes #389

---

## Changes

**Implementation:**
- Render the scroll-to-bottom control only when the message list is non-empty to avoid invalid animateScrollToItem calls.
- No other UI/logic changes.

**Tests:**
- Not run (not requested).

---

## Testing
- [ ] Unit tests pass
- [ ] Instrumentation tests pass
- [ ] Manual testing completed
- [ ] Coverage maintained (≥80%)

**Test summary:** Not run (not requested).

---

## Screenshots/Videos
Not applicable (no UI change)

---

## Checklist
- [ ] Sufficient documentation and minimal inline comments
- [ ] All tests passing
- [ ] No new warnings
- [ ] If related issue exists: issue has all labels, fields, and milestone filled