### PR TITLE
Refactor profile and badge UI logic

### DIFF
--- a/app/src/main/java/com/swent/mapin/ui/profile/BadgeSection.kt
+++ b/app/src/main/java/com/swent/mapin/ui/profile/BadgeSection.kt
@@ -156,72 +156,87 @@ private fun BadgeItem(badge: Badge, onClick: () -> Unit) {
   Column(
       horizontalAlignment = Alignment.CenterHorizontally,
       modifier = Modifier.testTag("badgeItem_${badge.id}").clickable { onClick() }) {
-        Box(contentAlignment = Alignment.Center) {
-          Box(
-              modifier =
-                  Modifier.size(56.dp)
-                      .alpha(alpha)
-                      .clip(CircleShape)
-                      .background(
-                          brush =
-                              if (badge.isUnlocked) {
-                                Brush.radialGradient(
-                                    colors = rarityColors,
-                                    center = androidx.compose.ui.geometry.Offset(28f, 28f),
-                                    radius = 40f)
-                              } else {
-                                Brush.radialGradient(
-                                    colors =
-                                        listOf(
-                                            MaterialTheme.colorScheme.surfaceVariant,
-                                            MaterialTheme.colorScheme.surfaceVariant))
-                              })
-                      .border(
-                          width = 2.dp,
-                          color =
-                              if (badge.isUnlocked) rarityColors.first().copy(alpha = 0.8f)
-                              else MaterialTheme.colorScheme.outline.copy(alpha = 0.3f),
-                          shape = CircleShape),
-              contentAlignment = Alignment.Center) {
-                Icon(
-                    imageVector =
-                        if (badge.isUnlocked) getIconFromName(badge.iconName)
-                        else Icons.Default.Lock,
-                    contentDescription = badge.title,
-                    modifier = Modifier.size(28.dp),
-                    tint =
-                        if (badge.isUnlocked) Color.White
-                        else MaterialTheme.colorScheme.onSurfaceVariant)
-              }
-
-          if (!badge.isUnlocked && badge.progress > 0) {
-            Box(
-                modifier = Modifier.size(60.dp).padding(2.dp),
-                contentAlignment = Alignment.BottomCenter) {
-                  LinearProgressIndicator(
-                      progress = badge.progress,
-                      modifier =
-                          Modifier.fillMaxWidth().height(3.dp).clip(RoundedCornerShape(2.dp)),
-                      color = rarityColors.first(),
-                      trackColor = Color.Transparent)
-                }
-          }
-        }
-
+        BadgeIconWithProgress(badge, alpha, rarityColors)
         Spacer(modifier = Modifier.height(4.dp))
 
-        Text(
-            text = badge.title,
-            style = MaterialTheme.typography.labelSmall,
-            fontWeight = if (badge.isUnlocked) FontWeight.SemiBold else FontWeight.Normal,
-            color =
-                if (badge.isUnlocked) MaterialTheme.colorScheme.onSurface
-                else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
-            textAlign = TextAlign.Center,
-            maxLines = 2,
-            overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.width(64.dp))
+        BadgeTitle(badge)
       }
+}
+
+@Composable
+private fun BadgeIconWithProgress(badge: Badge, alpha: Float, rarityColors: List<Color>) {
+  Box(contentAlignment = Alignment.Center) {
+    BadgeIconCircle(badge, alpha, rarityColors)
+
+    if (shouldShowProgressBar(badge)) {
+      Box(
+          modifier = Modifier.size(60.dp).padding(2.dp),
+          contentAlignment = Alignment.BottomCenter) {
+            LinearProgressIndicator(
+                progress = badge.progress,
+                modifier = Modifier.fillMaxWidth().height(3.dp).clip(RoundedCornerShape(2.dp)),
+                color = rarityColors.first(),
+                trackColor = Color.Transparent)
+          }
+    }
+  }
+}
+
+@Composable
+private fun BadgeIconCircle(badge: Badge, alpha: Float, rarityColors: List<Color>) {
+  Box(
+      modifier =
+          Modifier.size(56.dp)
+              .alpha(alpha)
+              .clip(CircleShape)
+              .background(
+                  brush =
+                      if (badge.isUnlocked) {
+                        Brush.radialGradient(
+                            colors = rarityColors,
+                            center = androidx.compose.ui.geometry.Offset(28f, 28f),
+                            radius = 40f)
+                      } else {
+                        Brush.radialGradient(
+                            colors =
+                                listOf(
+                                    MaterialTheme.colorScheme.surfaceVariant,
+                                    MaterialTheme.colorScheme.surfaceVariant))
+                      })
+              .border(
+                  width = 2.dp,
+                  color =
+                      if (badge.isUnlocked) rarityColors.first().copy(alpha = 0.8f)
+                      else MaterialTheme.colorScheme.outline.copy(alpha = 0.3f),
+                  shape = CircleShape),
+      contentAlignment = Alignment.Center) {
+        Icon(
+            imageVector =
+                if (badge.isUnlocked) getIconFromName(badge.iconName) else Icons.Default.Lock,
+            contentDescription = badge.title,
+            modifier = Modifier.size(28.dp),
+            tint =
+                if (badge.isUnlocked) Color.White else MaterialTheme.colorScheme.onSurfaceVariant)
+      }
+}
+
+@Composable
+private fun BadgeTitle(badge: Badge) {
+  Text(
+      text = badge.title,
+      style = MaterialTheme.typography.labelSmall,
+      fontWeight = if (badge.isUnlocked) FontWeight.SemiBold else FontWeight.Normal,
+      color =
+          if (badge.isUnlocked) MaterialTheme.colorScheme.onSurface
+          else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+      textAlign = TextAlign.Center,
+      maxLines = 2,
+      overflow = TextOverflow.Ellipsis,
+      modifier = Modifier.width(64.dp))
+}
+
+private fun shouldShowProgressBar(badge: Badge): Boolean {
+  return !badge.isUnlocked && badge.progress > 0
 }
 
 /**
@@ -239,111 +254,8 @@ private fun BadgeDetailDialog(badge: Badge, onDismiss: () -> Unit = {}) {
 
   AlertDialog(
       onDismissRequest = onDismiss,
-      title = {
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            modifier = Modifier.fillMaxWidth()) {
-              Box(
-                  modifier =
-                      Modifier.size(80.dp)
-                          .clip(CircleShape)
-                          .background(
-                              brush =
-                                  Brush.radialGradient(
-                                      colors =
-                                          if (badge.isUnlocked) rarityColors
-                                          else
-                                              listOf(
-                                                  MaterialTheme.colorScheme.surfaceVariant,
-                                                  MaterialTheme.colorScheme.surfaceVariant)))
-                          .border(
-                              width = 3.dp,
-                              color =
-                                  if (badge.isUnlocked) rarityColors.first().copy(alpha = 0.8f)
-                                  else MaterialTheme.colorScheme.outline.copy(alpha = 0.3f),
-                              shape = CircleShape),
-                  contentAlignment = Alignment.Center) {
-                    Icon(
-                        imageVector =
-                            if (badge.isUnlocked) getIconFromName(badge.iconName)
-                            else Icons.Default.Lock,
-                        contentDescription = badge.title,
-                        modifier = Modifier.size(40.dp),
-                        tint =
-                            if (badge.isUnlocked) Color.White
-                            else MaterialTheme.colorScheme.onSurfaceVariant)
-                  }
-
-              Spacer(modifier = Modifier.height(12.dp))
-              Text(
-                  text = badge.title,
-                  style = MaterialTheme.typography.headlineSmall,
-                  fontWeight = FontWeight.Bold,
-                  textAlign = TextAlign.Center)
-              Spacer(modifier = Modifier.height(4.dp))
-              Text(
-                  text = badge.rarity.name.lowercase().replaceFirstChar { it.uppercase() },
-                  style = MaterialTheme.typography.labelMedium,
-                  color = rarityColors.first(),
-                  fontWeight = FontWeight.SemiBold)
-            }
-      },
-      text = {
-        Column {
-          Text(
-              text = badge.description,
-              style = MaterialTheme.typography.bodyMedium,
-              textAlign = TextAlign.Center,
-              modifier = Modifier.fillMaxWidth())
-
-          when {
-            !badge.isUnlocked && badge.progress > 0 -> {
-              Spacer(modifier = Modifier.height(16.dp))
-              Column(modifier = Modifier.fillMaxWidth()) {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween) {
-                      Text(
-                          text = "Progress",
-                          style = MaterialTheme.typography.labelMedium,
-                          color = MaterialTheme.colorScheme.onSurfaceVariant)
-                      Text(
-                          text = "${(badge.progress * 100).toInt()}%",
-                          style = MaterialTheme.typography.labelMedium,
-                          fontWeight = FontWeight.SemiBold,
-                          color = rarityColors.first())
-                    }
-                Spacer(modifier = Modifier.height(8.dp))
-                LinearProgressIndicator(
-                    progress = badge.progress,
-                    modifier = Modifier.fillMaxWidth().height(8.dp).clip(RoundedCornerShape(4.dp)),
-                    color = rarityColors.first(),
-                    trackColor = MaterialTheme.colorScheme.surfaceVariant)
-              }
-            }
-            badge.isUnlocked -> {
-              Spacer(modifier = Modifier.height(8.dp))
-              Text(
-                  text = "✓ Unlocked",
-                  style = MaterialTheme.typography.labelLarge,
-                  color = rarityColors.first(),
-                  fontWeight = FontWeight.Bold,
-                  textAlign = TextAlign.Center,
-                  modifier = Modifier.fillMaxWidth())
-            }
-            else -> {
-              Spacer(modifier = Modifier.height(8.dp))
-              Text(
-                  text = "🔒 Locked",
-                  style = MaterialTheme.typography.labelLarge,
-                  color = MaterialTheme.colorScheme.onSurfaceVariant,
-                  fontWeight = FontWeight.Bold,
-                  textAlign = TextAlign.Center,
-                  modifier = Modifier.fillMaxWidth())
-            }
-          }
-        }
-      },
+      title = { BadgeDialogHeader(badge, rarityColors) },
+      text = { BadgeDialogContent(badge, rarityColors) },
       confirmButton = {
         Button(
             onClick = onDismiss,
@@ -353,6 +265,121 @@ private fun BadgeDetailDialog(badge: Badge, onDismiss: () -> Unit = {}) {
       },
       containerColor = MaterialTheme.colorScheme.surface,
       shape = RoundedCornerShape(24.dp))
+}
+
+@Composable
+private fun BadgeDialogHeader(badge: Badge, rarityColors: List<Color>) {
+  Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = Modifier.fillMaxWidth()) {
+    Box(
+        modifier =
+            Modifier.size(80.dp)
+                .clip(CircleShape)
+                .background(
+                    brush =
+                        Brush.radialGradient(
+                            colors =
+                                if (badge.isUnlocked) rarityColors
+                                else
+                                    listOf(
+                                        MaterialTheme.colorScheme.surfaceVariant,
+                                        MaterialTheme.colorScheme.surfaceVariant)))
+                .border(
+                    width = 3.dp,
+                    color =
+                        if (badge.isUnlocked) rarityColors.first().copy(alpha = 0.8f)
+                        else MaterialTheme.colorScheme.outline.copy(alpha = 0.3f),
+                    shape = CircleShape),
+        contentAlignment = Alignment.Center) {
+          Icon(
+              imageVector =
+                  if (badge.isUnlocked) getIconFromName(badge.iconName) else Icons.Default.Lock,
+              contentDescription = badge.title,
+              modifier = Modifier.size(40.dp),
+              tint =
+                  if (badge.isUnlocked) Color.White else MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+
+    Spacer(modifier = Modifier.height(12.dp))
+    Text(
+        text = badge.title,
+        style = MaterialTheme.typography.headlineSmall,
+        fontWeight = FontWeight.Bold,
+        textAlign = TextAlign.Center)
+    Spacer(modifier = Modifier.height(4.dp))
+    Text(
+        text = badge.rarity.name.lowercase().replaceFirstChar { it.uppercase() },
+        style = MaterialTheme.typography.labelMedium,
+        color = rarityColors.first(),
+        fontWeight = FontWeight.SemiBold)
+  }
+}
+
+@Composable
+private fun BadgeDialogContent(badge: Badge, rarityColors: List<Color>) {
+  Column {
+    Text(
+        text = badge.description,
+        style = MaterialTheme.typography.bodyMedium,
+        textAlign = TextAlign.Center,
+        modifier = Modifier.fillMaxWidth())
+
+    Spacer(modifier = Modifier.height(8.dp))
+    BadgeDialogStatus(badge, rarityColors)
+  }
+}
+
+@Composable
+private fun BadgeDialogStatus(badge: Badge, rarityColors: List<Color>) {
+  when {
+    shouldShowProgressBar(badge) -> BadgeProgressSection(badge, rarityColors)
+    badge.isUnlocked -> BadgeUnlockedLabel(rarityColors)
+    else -> BadgeLockedLabel()
+  }
+}
+
+@Composable
+private fun BadgeProgressSection(badge: Badge, rarityColors: List<Color>) {
+  Column(modifier = Modifier.fillMaxWidth()) {
+    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+      Text(
+          text = "Progress",
+          style = MaterialTheme.typography.labelMedium,
+          color = MaterialTheme.colorScheme.onSurfaceVariant)
+      Text(
+          text = "${(badge.progress * 100).toInt()}%",
+          style = MaterialTheme.typography.labelMedium,
+          fontWeight = FontWeight.SemiBold,
+          color = rarityColors.first())
+    }
+    Spacer(modifier = Modifier.height(8.dp))
+    LinearProgressIndicator(
+        progress = badge.progress,
+        modifier = Modifier.fillMaxWidth().height(8.dp).clip(RoundedCornerShape(4.dp)),
+        color = rarityColors.first(),
+        trackColor = MaterialTheme.colorScheme.surfaceVariant)
+  }
+}
+
+@Composable
+private fun BadgeUnlockedLabel(rarityColors: List<Color>) {
+  Text(
+      text = "✓ Unlocked",
+      style = MaterialTheme.typography.labelLarge,
+      color = rarityColors.first(),
+      fontWeight = FontWeight.Bold,
+      textAlign = TextAlign.Center,
+      modifier = Modifier.fillMaxWidth())
+}
+
+@Composable
+private fun BadgeLockedLabel() {
+  Text(
+      text = "🔒 Locked",
+      style = MaterialTheme.typography.labelLarge,
+      color = MaterialTheme.colorScheme.onSurfaceVariant,
+      fontWeight = FontWeight.Bold,
+      textAlign = TextAlign.Center,
+      modifier = Modifier.fillMaxWidth())
 }
 
 /**

--- a/app/src/main/java/com/swent/mapin/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/swent/mapin/ui/profile/ProfileScreen.kt
@@ -6,11 +6,13 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.spring
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -91,114 +93,133 @@ fun ProfileScreen(onNavigateBack: () -> Unit, viewModel: ProfileViewModel = view
   Scaffold(
       modifier = Modifier.fillMaxSize().testTag("profileScreen"),
       topBar = {
-        TopAppBar(
-            title = {
-              Text(
-                  "Profile",
-                  style = MaterialTheme.typography.headlineSmall,
-                  fontWeight = FontWeight.Bold)
-            },
-            navigationIcon = {
-              IconButton(
-                  onClick = {
-                    if (viewModel.isEditMode) {
-                      viewModel.cancelEditing()
-                    } else {
-                      onNavigateBack()
-                    }
-                  },
-                  modifier = Modifier.testTag("backButton")) {
-                    Icon(
-                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                        contentDescription = "Back")
-                  }
-            },
-            actions = {
-              if (!viewModel.isEditMode) {
-                FloatingActionButton(
-                    onClick = { viewModel.startEditing() },
-                    modifier = Modifier.testTag("editButton").padding(end = 8.dp).size(48.dp),
-                    containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                    contentColor = MaterialTheme.colorScheme.onSecondaryContainer) {
-                      Icon(
-                          imageVector = Icons.Default.Edit,
-                          contentDescription = "Edit Profile",
-                          modifier = Modifier.size(24.dp))
-                    }
+        ProfileTopBar(
+            isEditMode = viewModel.isEditMode,
+            onNavigateBack = {
+              if (viewModel.isEditMode) {
+                viewModel.cancelEditing()
+              } else {
+                onNavigateBack()
               }
             },
-            colors =
-                TopAppBarDefaults.topAppBarColors(
-                    containerColor = Color.Transparent,
-                    titleContentColor = MaterialTheme.colorScheme.onSurface,
-                    navigationIconContentColor = MaterialTheme.colorScheme.onSurface))
+            onStartEditing = { viewModel.startEditing() })
       }) { paddingValues ->
-        Box(modifier = Modifier.fillMaxSize()) {
-          Column(
-              modifier =
-                  Modifier.fillMaxSize()
-                      .imePadding()
-                      .padding(paddingValues)
-                      .padding(horizontal = 20.dp)
-                      .verticalScroll(scrollState)
-                      .animateContentSize(
-                          animationSpec =
-                              spring(
-                                  dampingRatio = Spring.DampingRatioMediumBouncy,
-                                  stiffness = Spring.StiffnessLow)),
-              horizontalAlignment = Alignment.CenterHorizontally) {
-                // Add top spacing
-                Spacer(modifier = Modifier.height(24.dp))
+        ProfileContent(
+            paddingValues = paddingValues,
+            scrollState = scrollState,
+            viewModel = viewModel,
+            userProfile = userProfile)
 
-                // Profile picture is now part of the scrollable content
-                ProfilePicture(
-                    avatarUrl =
-                        if (viewModel.isEditMode && viewModel.selectedAvatar.isNotEmpty()) {
-                          viewModel.selectedAvatar
-                        } else {
-                          userProfile.avatarUrl
-                        },
-                    isEditMode = viewModel.isEditMode,
-                    onAvatarClick = { viewModel.toggleAvatarSelector() })
-
-                Spacer(modifier = Modifier.height(16.dp))
-
-                if (viewModel.isEditMode) {
-                  EditProfileContent(viewModel = viewModel)
-                } else {
-                  ViewProfileContent(userProfile = userProfile, viewModel = viewModel)
-
-                  Spacer(modifier = Modifier.height(24.dp))
-                }
-
-                Spacer(modifier = Modifier.height(16.dp))
-              }
-
-          // Avatar Selector Dialog
-          if (viewModel.showAvatarSelector) {
-            AvatarSelectorDialog(
-                viewModel = viewModel,
-                selectedAvatar = viewModel.selectedAvatar,
-                onAvatarSelected = { avatarUrl ->
-                  viewModel.updateAvatarSelection(avatarUrl)
-                  viewModel.toggleAvatarSelector()
-                },
-                onDismiss = { viewModel.toggleAvatarSelector() })
-          }
-
-          // Banner Selector Dialog (new: show when viewModel.showBannerSelector is true)
-          if (viewModel.showBannerSelector) {
-            BannerSelectorDialog(
-                viewModel = viewModel,
-                selectedBanner = viewModel.selectedBanner,
-                onBannerSelected = { bannerUrl ->
-                  viewModel.updateBannerSelection(bannerUrl)
-                  viewModel.toggleBannerSelector()
-                },
-                onDismiss = { viewModel.toggleBannerSelector() })
-          }
-        }
+        ProfileDialogs(viewModel)
       }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ProfileTopBar(
+    isEditMode: Boolean,
+    onNavigateBack: () -> Unit,
+    onStartEditing: () -> Unit
+) {
+  TopAppBar(
+      title = {
+        Text(
+            "Profile", style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.Bold)
+      },
+      navigationIcon = {
+        IconButton(onClick = onNavigateBack, modifier = Modifier.testTag("backButton")) {
+          Icon(imageVector = Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+        }
+      },
+      actions = {
+        if (!isEditMode) {
+          FloatingActionButton(
+              onClick = onStartEditing,
+              modifier = Modifier.testTag("editButton").padding(end = 8.dp).size(48.dp),
+              containerColor = MaterialTheme.colorScheme.secondaryContainer,
+              contentColor = MaterialTheme.colorScheme.onSecondaryContainer) {
+                Icon(
+                    imageVector = Icons.Default.Edit,
+                    contentDescription = "Edit Profile",
+                    modifier = Modifier.size(24.dp))
+              }
+        }
+      },
+      colors =
+          TopAppBarDefaults.topAppBarColors(
+              containerColor = Color.Transparent,
+              titleContentColor = MaterialTheme.colorScheme.onSurface,
+              navigationIconContentColor = MaterialTheme.colorScheme.onSurface))
+}
+
+@Composable
+private fun ProfileContent(
+    paddingValues: PaddingValues,
+    scrollState: ScrollState,
+    viewModel: ProfileViewModel,
+    userProfile: UserProfile
+) {
+  Column(
+      modifier =
+          Modifier.fillMaxSize()
+              .imePadding()
+              .padding(paddingValues)
+              .padding(horizontal = 20.dp)
+              .verticalScroll(scrollState)
+              .animateContentSize(
+                  animationSpec =
+                      spring(
+                          dampingRatio = Spring.DampingRatioMediumBouncy,
+                          stiffness = Spring.StiffnessLow)),
+      horizontalAlignment = Alignment.CenterHorizontally) {
+        Spacer(modifier = Modifier.height(24.dp))
+
+        ProfilePicture(
+            avatarUrl =
+                if (viewModel.isEditMode && viewModel.selectedAvatar.isNotEmpty()) {
+                  viewModel.selectedAvatar
+                } else {
+                  userProfile.avatarUrl
+                },
+            isEditMode = viewModel.isEditMode,
+            onAvatarClick = { viewModel.toggleAvatarSelector() })
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        if (viewModel.isEditMode) {
+          EditProfileContent(viewModel = viewModel)
+        } else {
+          ViewProfileContent(userProfile = userProfile, viewModel = viewModel)
+          Spacer(modifier = Modifier.height(24.dp))
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+      }
+}
+
+@Composable
+private fun ProfileDialogs(viewModel: ProfileViewModel) {
+  if (viewModel.showAvatarSelector) {
+    AvatarSelectorDialog(
+        viewModel = viewModel,
+        selectedAvatar = viewModel.selectedAvatar,
+        onAvatarSelected = { avatarUrl ->
+          viewModel.updateAvatarSelection(avatarUrl)
+          viewModel.toggleAvatarSelector()
+        },
+        onDismiss = { viewModel.toggleAvatarSelector() })
+  }
+
+  if (viewModel.showBannerSelector) {
+    BannerSelectorDialog(
+        viewModel = viewModel,
+        selectedBanner = viewModel.selectedBanner,
+        onBannerSelected = { bannerUrl ->
+          viewModel.updateBannerSelection(bannerUrl)
+          viewModel.toggleBannerSelector()
+        },
+        onDismiss = { viewModel.toggleBannerSelector() })
+  }
 }
 
 /** Displays the user's profile picture or a placeholder. */


### PR DESCRIPTION
## Description
Refactors profile UI and badge syncing to reduce complexity by extracting focused helpers for layout, dialogs, and badge context handling.

**Related Issue:** N/A

---

## Changes

**Implementation:**
- Split ProfileScreen top bar, content, and dialogs into dedicated composables for clearer flow.
- Refactored ProfileViewModel badge context fetching/cache sync into smaller suspend helpers with safer retries.
- Extracted BadgeSection icon/progress/title and dialog header/content/status helpers for readability.

**Tests:**
- `./gradlew :app:testDebugUnitTest --tests com.swent.mapin.ui.profile.ProfileViewModelTest`
- `./gradlew :app:connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.swent.mapin.ui.profile.BadgeSectionTest`

---

## Testing
- [x] Unit tests pass
- [x] Instrumentation tests pass
- [ ] Manual testing completed
- [ ] Coverage maintained (≥80%)

**Test summary:** Ran ProfileViewModel unit tests and BadgeSection instrumentation suite after refactor.

---

## Screenshots/Videos
N/A

---

## Checklist
- [x] Sufficient documentation and minimal inline comments
- [x] All tests passing
- [x] No new warnings
- [ ] If related issue exists: issue has all labels, fields, and milestone filled
