### PR TITLE
Refactor search UI and add EventPickerDialog coverage

### DIFF
--- a/app/src/androidTest/java/com/swent/mapin/ui/event/EventPickerDialogAndroidTest.kt
+++ b/app/src/androidTest/java/com/swent/mapin/ui/event/EventPickerDialogAndroidTest.kt
@@ -1,0 +1,83 @@
+package com.swent.mapin.ui.event
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import com.google.firebase.Timestamp
+import com.swent.mapin.model.event.Event
+import com.swent.mapin.model.location.Location
+import java.util.Calendar
+import org.junit.Rule
+import org.junit.Test
+
+class EventPickerDialogAndroidTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  private val sampleEvents =
+      listOf(
+          testEvent(id = "1", title = "Alpha Event", locationName = "Zurich"),
+          testEvent(id = "2", title = "Beta Event", locationName = "Geneva"))
+
+  @Test
+  fun eventPicker_showsEvents_andSelectsItem() {
+    var selectedId: String? = null
+    composeTestRule.setContent {
+      EventPickerDialog(events = sampleEvents, onEventSelected = { selectedId = it.uid }) {}
+    }
+
+    composeTestRule.onNodeWithTag("eventPickerSearch").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("eventPickerList").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("eventPickerItem_1").assertIsDisplayed()
+
+    composeTestRule.onNodeWithTag("eventPickerItem_1").performClick()
+    composeTestRule.waitForIdle()
+
+    assert(selectedId == "1")
+  }
+
+  @Test
+  fun eventPicker_filtersByQuery() {
+    composeTestRule.setContent {
+      EventPickerDialog(events = sampleEvents, onEventSelected = {}, onDismiss = {})
+    }
+
+    composeTestRule.onNodeWithTag("eventPickerSearch").performTextInput("Beta")
+    composeTestRule.waitForIdle()
+
+    composeTestRule.onNodeWithTag("eventPickerItem_2").assertIsDisplayed()
+    composeTestRule.onNodeWithText("Alpha Event").assertDoesNotExist()
+  }
+
+  @Test
+  fun eventPicker_showsEmptyState_whenNoEvents() {
+    composeTestRule.setContent {
+      EventPickerDialog(events = emptyList(), onEventSelected = {}, onDismiss = {})
+    }
+
+    composeTestRule.onNodeWithTag("eventPickerEmpty").assertIsDisplayed()
+    composeTestRule.onNodeWithText("No events available").assertIsDisplayed()
+  }
+
+  private fun testEvent(
+      id: String,
+      title: String,
+      locationName: String,
+      year: Int = 2025,
+      month: Int = Calendar.JANUARY,
+      day: Int = 1
+  ): Event {
+    val timestamp =
+        Timestamp(
+            Calendar.getInstance().apply { set(year, month, day, 10, 0, 0) }.time.time / 1000, 0)
+    return Event(
+        uid = id,
+        title = title,
+        description = "Description for $title",
+        date = timestamp,
+        location = Location.from(locationName, 0.0, 0.0))
+  }
+}

--- a/app/src/main/java/com/swent/mapin/ui/event/EventPickerDialog.kt
+++ b/app/src/main/java/com/swent/mapin/ui/event/EventPickerDialog.kt
@@ -1,5 +1,6 @@
 package com.swent.mapin.ui.event
 
+import androidx.annotation.VisibleForTesting
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -31,6 +32,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.swent.mapin.model.event.Event
 import com.swent.mapin.model.location.Location
@@ -56,97 +58,133 @@ fun EventPickerDialog(
 ) {
   var searchQuery by remember { mutableStateOf("") }
 
-  val filteredEvents =
-      remember(events, searchQuery) {
-        if (searchQuery.isBlank()) {
-          events
-        } else {
-          events.filter {
-            it.title.contains(searchQuery, ignoreCase = true) ||
-                it.location.name?.contains(searchQuery, ignoreCase = true) ?: false ||
-                it.description.contains(searchQuery, ignoreCase = true)
-          }
-        }
-      }
+  val filteredEvents = remember(events, searchQuery) { filterEvents(events, searchQuery) }
 
   AlertDialog(
       onDismissRequest = onDismiss,
       title = { Text("Select an event", style = MaterialTheme.typography.titleLarge) },
       text = {
-        Column(modifier = Modifier.fillMaxWidth()) {
-          OutlinedTextField(
-              value = searchQuery,
-              onValueChange = { searchQuery = it },
-              modifier = Modifier.fillMaxWidth(),
-              placeholder = { Text("Search events...") },
-              leadingIcon = {
-                Icon(imageVector = Icons.Default.Search, contentDescription = "Search")
-              },
-              trailingIcon = {
-                if (searchQuery.isNotEmpty()) {
-                  IconButton(onClick = { searchQuery = "" }) {
-                    Icon(imageVector = Icons.Default.Close, contentDescription = "Clear search")
-                  }
-                }
-              },
-              singleLine = true)
-
-          Spacer(modifier = Modifier.height(16.dp))
-
-          if (filteredEvents.isEmpty()) {
-            Box(
-                modifier = Modifier.fillMaxWidth().height(200.dp),
-                contentAlignment = Alignment.Center) {
-                  Text(
-                      text =
-                          if (searchQuery.isBlank()) "No events available" else "No events found",
-                      style = MaterialTheme.typography.bodyMedium,
-                      color = MaterialTheme.colorScheme.onSurfaceVariant)
-                }
-          } else {
-            LazyColumn(modifier = Modifier.fillMaxWidth().height(EVENT_DIALOG_LIST_HEIGHT)) {
-              items(filteredEvents) { event ->
-                Card(
-                    modifier =
-                        Modifier.fillMaxWidth().padding(vertical = 4.dp).clickable {
-                          onEventSelected(event)
-                        },
-                    colors =
-                        CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
-                    shape = RoundedCornerShape(8.dp)) {
-                      Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
-                        Text(
-                            text = event.title,
-                            style = MaterialTheme.typography.bodyLarge,
-                            color = MaterialTheme.colorScheme.onSurface)
-                        Spacer(modifier = Modifier.height(4.dp))
-                        Row(
-                            horizontalArrangement = Arrangement.spacedBy(8.dp),
-                            verticalAlignment = Alignment.CenterVertically) {
-                              val dateStr =
-                                  event.date?.let {
-                                    SimpleDateFormat("MMM dd, yyyy", Locale.getDefault())
-                                        .format(it.toDate())
-                                  } ?: "No date"
-                              Text(
-                                  text = dateStr,
-                                  style = MaterialTheme.typography.bodySmall,
-                                  color = MaterialTheme.colorScheme.onSurfaceVariant)
-                              Text(
-                                  text = "•",
-                                  style = MaterialTheme.typography.bodySmall,
-                                  color = MaterialTheme.colorScheme.onSurfaceVariant)
-                              Text(
-                                  text = event.location.name ?: Location.NO_NAME,
-                                  style = MaterialTheme.typography.bodySmall,
-                                  color = MaterialTheme.colorScheme.onSurfaceVariant)
-                            }
-                      }
-                    }
-              }
-            }
-          }
-        }
+        EventPickerContent(
+            searchQuery = searchQuery,
+            onSearchQueryChange = { searchQuery = it },
+            filteredEvents = filteredEvents,
+            onEventSelected = onEventSelected)
       },
       confirmButton = { TextButton(onClick = onDismiss) { Text("Cancel") } })
+}
+
+@Composable
+private fun EventPickerContent(
+    searchQuery: String,
+    onSearchQueryChange: (String) -> Unit,
+    filteredEvents: List<Event>,
+    onEventSelected: (Event) -> Unit
+) {
+  Column(modifier = Modifier.fillMaxWidth()) {
+    EventSearchField(searchQuery, onSearchQueryChange)
+    Spacer(modifier = Modifier.height(16.dp))
+    EventPickerList(filteredEvents, searchQuery, onEventSelected)
+  }
+}
+
+@Composable
+private fun EventPickerList(
+    events: List<Event>,
+    searchQuery: String,
+    onEventSelected: (Event) -> Unit
+) {
+  if (events.isEmpty()) {
+    EmptyEventState(searchQuery)
+    return
+  }
+
+  LazyColumn(
+      modifier =
+          Modifier.fillMaxWidth().height(EVENT_DIALOG_LIST_HEIGHT).testTag("eventPickerList")) {
+        items(events) { event -> EventListItem(event, onEventSelected) }
+      }
+}
+
+@Composable
+private fun EventListItem(event: Event, onEventSelected: (Event) -> Unit) {
+  Card(
+      modifier =
+          Modifier.fillMaxWidth()
+              .padding(vertical = 4.dp)
+              .clickable { onEventSelected(event) }
+              .testTag("eventPickerItem_${event.uid}"),
+      colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+      shape = RoundedCornerShape(8.dp)) {
+        Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+          Text(
+              text = event.title,
+              style = MaterialTheme.typography.bodyLarge,
+              color = MaterialTheme.colorScheme.onSurface)
+          Spacer(modifier = Modifier.height(4.dp))
+          Row(
+              horizontalArrangement = Arrangement.spacedBy(8.dp),
+              verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = event.date?.let { formatEventDate(it) } ?: "No date",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant)
+                Text(
+                    text = "•",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant)
+                Text(
+                    text = event.location.name ?: Location.NO_NAME,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant)
+              }
+        }
+      }
+}
+
+@Composable
+private fun EventSearchField(searchQuery: String, onSearchQueryChange: (String) -> Unit) {
+  OutlinedTextField(
+      value = searchQuery,
+      onValueChange = onSearchQueryChange,
+      modifier = Modifier.fillMaxWidth().testTag("eventPickerSearch"),
+      placeholder = { Text("Search events...") },
+      leadingIcon = { Icon(imageVector = Icons.Default.Search, contentDescription = "Search") },
+      trailingIcon = { ClearSearchIcon(searchQuery, onSearchQueryChange) },
+      singleLine = true)
+}
+
+@Composable
+private fun ClearSearchIcon(searchQuery: String, onSearchQueryChange: (String) -> Unit) {
+  if (searchQuery.isEmpty()) return
+  IconButton(onClick = { onSearchQueryChange("") }) {
+    Icon(imageVector = Icons.Default.Close, contentDescription = "Clear search")
+  }
+}
+
+@Composable
+private fun EmptyEventState(searchQuery: String) {
+  val message = if (searchQuery.isBlank()) "No events available" else "No events found"
+  Box(
+      modifier = Modifier.fillMaxWidth().height(200.dp).testTag("eventPickerEmpty"),
+      contentAlignment = Alignment.Center) {
+        Text(
+            text = message,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant)
+      }
+}
+
+@VisibleForTesting
+internal fun filterEvents(events: List<Event>, query: String): List<Event> {
+  if (query.isBlank()) return events
+  return events.filter {
+    it.title.contains(query, ignoreCase = true) ||
+        it.location.name?.contains(query, ignoreCase = true) ?: false ||
+        it.description.contains(query, ignoreCase = true)
+  }
+}
+
+@VisibleForTesting
+internal fun formatEventDate(timestamp: com.google.firebase.Timestamp): String {
+  return SimpleDateFormat("MMM dd, yyyy", Locale.getDefault()).format(timestamp.toDate())
 }

--- a/app/src/main/java/com/swent/mapin/ui/map/bottomsheet/components/SearchComponents.kt
+++ b/app/src/main/java/com/swent/mapin/ui/map/bottomsheet/components/SearchComponents.kt
@@ -58,9 +58,12 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.swent.mapin.model.UserProfile
@@ -279,121 +282,170 @@ fun SearchBar(
   var isFocused by remember { mutableStateOf(false) }
   val profileVisible = !isFocused && !isSearchMode
   val fieldHeight = TextFieldDefaults.MinHeight
-  var textFieldValueState by remember {
-    mutableStateOf(androidx.compose.ui.text.input.TextFieldValue(value))
-  }
+  var textFieldValueState by remember { mutableStateOf(TextFieldValue(value)) }
 
-  // Update text field value when value changes, preserving cursor at end
-  LaunchedEffect(value) {
-    if (textFieldValueState.text != value) {
-      textFieldValueState =
-          androidx.compose.ui.text.input.TextFieldValue(
-              text = value, selection = androidx.compose.ui.text.TextRange(value.length))
-    }
-  }
-
-  // When focus is gained and there's text, move cursor to end
-  LaunchedEffect(isFocused, value) {
-    if (isFocused && value.isNotEmpty() && textFieldValueState.selection.start == 0) {
-      textFieldValueState =
-          androidx.compose.ui.text.input.TextFieldValue(
-              text = value, selection = androidx.compose.ui.text.TextRange(value.length))
-    }
-  }
+  SyncTextFieldValue(value, textFieldValueState) { textFieldValueState = it }
+  MoveCursorToEndOnFocus(isFocused, value, textFieldValueState) { textFieldValueState = it }
 
   Row(modifier = modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
-    TextField(
+    SearchInputField(
         value = textFieldValueState,
-        onValueChange = { newValue ->
-          textFieldValueState = newValue
-          onValueChange(newValue.text)
+        onValueChange = {
+          textFieldValueState = it
+          onValueChange(it.text)
         },
-        placeholder = { Text("Search events, people", style = MaterialTheme.typography.bodyLarge) },
-        modifier =
-            Modifier.weight(1f).height(fieldHeight).focusRequester(focusRequester).onFocusChanged {
-                focusState ->
-              val nowFocused = focusState.isFocused
-              if (nowFocused && !isFocused) onTap()
-              isFocused = nowFocused
-            },
-        singleLine = true,
-        textStyle = MaterialTheme.typography.bodyLarge,
-        trailingIcon = {
-          AnimatedVisibility(
-              visible = isSearchMode || value.isNotEmpty(),
-              enter =
-                  fadeIn(animationSpec = tween(durationMillis = 200, easing = FastOutSlowInEasing)),
-              exit =
-                  fadeOut(
-                      animationSpec = tween(durationMillis = 160, easing = FastOutSlowInEasing))) {
-                IconButton(onClick = onClear) {
-                  Icon(imageVector = Icons.Filled.Close, contentDescription = "Clear search")
-                }
-              }
-        },
-        shape = RoundedCornerShape(16.dp),
-        colors =
-            TextFieldDefaults.colors(
-                focusedContainerColor =
-                    MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.85f),
-                unfocusedContainerColor =
-                    MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.55f),
-                focusedIndicatorColor = Color.Transparent,
-                unfocusedIndicatorColor = Color.Transparent,
-                disabledIndicatorColor = Color.Transparent),
-        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
-        keyboardActions = KeyboardActions(onSearch = { onSearchAction() }))
+        onTap = onTap,
+        onFocusChange = { isFocused = it },
+        isSearchMode = isSearchMode,
+        currentText = value,
+        focusRequester = focusRequester,
+        fieldHeight = fieldHeight,
+        onSearchAction = onSearchAction,
+        onClear = onClear,
+        modifier = Modifier.weight(1f).height(fieldHeight))
 
-    val profileSlotWidth by
-        animateDpAsState(
-            targetValue = if (profileVisible) fieldHeight else 0.dp,
-            animationSpec =
-                tween(
-                    durationMillis = if (profileVisible) 220 else 180,
-                    easing = FastOutSlowInEasing),
-            label = "profileWidth")
+    ProfileButtonSlot(
+        profileVisible = profileVisible,
+        fieldHeight = fieldHeight,
+        avatarUrl = avatarUrl,
+        onProfileClick = onProfileClick)
+  }
+}
 
-    val profileAlpha by
-        animateFloatAsState(
-            targetValue = if (profileVisible) 1f else 0f,
-            animationSpec =
-                tween(
-                    durationMillis = if (profileVisible) 220 else 180,
-                    easing = FastOutSlowInEasing),
-            label = "profileFade")
+@Composable
+private fun SearchInputField(
+    value: TextFieldValue,
+    onValueChange: (TextFieldValue) -> Unit,
+    onTap: () -> Unit,
+    onFocusChange: (Boolean) -> Unit,
+    isSearchMode: Boolean,
+    currentText: String,
+    focusRequester: FocusRequester,
+    fieldHeight: Dp,
+    onSearchAction: () -> Unit,
+    onClear: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+  TextField(
+      value = value,
+      onValueChange = onValueChange,
+      placeholder = { Text("Search events, people", style = MaterialTheme.typography.bodyLarge) },
+      modifier =
+          modifier.focusRequester(focusRequester).onFocusChanged { focusState ->
+            val nowFocused = focusState.isFocused
+            if (nowFocused) onTap()
+            onFocusChange(nowFocused)
+          },
+      singleLine = true,
+      textStyle = MaterialTheme.typography.bodyLarge,
+      trailingIcon = {
+        SearchTrailingIcon(visible = isSearchMode || currentText.isNotEmpty(), onClear = onClear)
+      },
+      shape = RoundedCornerShape(16.dp),
+      colors =
+          TextFieldDefaults.colors(
+              focusedContainerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.85f),
+              unfocusedContainerColor =
+                  MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.55f),
+              focusedIndicatorColor = Color.Transparent,
+              unfocusedIndicatorColor = Color.Transparent,
+              disabledIndicatorColor = Color.Transparent),
+      keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+      keyboardActions = KeyboardActions(onSearch = { onSearchAction() }))
+}
 
-    val slotPadding = if (profileSlotWidth > 0.dp) 12.dp else 0.dp
-
-    Box(
-        modifier =
-            Modifier.padding(start = slotPadding).height(fieldHeight).width(profileSlotWidth),
-        contentAlignment = Alignment.Center) {
-          Surface(
-              modifier = Modifier.fillMaxSize().testTag("profileButton").alpha(profileAlpha),
-              color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f),
-              shape = RoundedCornerShape(16.dp)) {
-                Box(
-                    modifier =
-                        Modifier.fillMaxSize().clickable(enabled = profileVisible) {
-                          onProfileClick()
-                        },
-                    contentAlignment = Alignment.Center) {
-                      if (!avatarUrl.isNullOrEmpty() && avatarUrl.startsWith("http")) {
-                        AsyncImage(
-                            model = avatarUrl,
-                            contentDescription = "Profile Picture",
-                            contentScale = ContentScale.Crop,
-                            modifier = Modifier.fillMaxSize().clip(RoundedCornerShape(16.dp)))
-                      } else {
-                        Icon(
-                            imageVector = getAvatarIcon(avatarUrl),
-                            contentDescription = "Profile",
-                            modifier = Modifier.fillMaxSize(),
-                            tint = MaterialTheme.colorScheme.onSurface)
-                      }
-                    }
-              }
+@Composable
+private fun SearchTrailingIcon(visible: Boolean, onClear: () -> Unit) {
+  AnimatedVisibility(
+      visible = visible,
+      enter = fadeIn(animationSpec = tween(durationMillis = 200, easing = FastOutSlowInEasing)),
+      exit = fadeOut(animationSpec = tween(durationMillis = 160, easing = FastOutSlowInEasing))) {
+        IconButton(onClick = onClear) {
+          Icon(imageVector = Icons.Filled.Close, contentDescription = "Clear search")
         }
+      }
+}
+
+@Composable
+private fun ProfileButtonSlot(
+    profileVisible: Boolean,
+    fieldHeight: Dp,
+    avatarUrl: String?,
+    onProfileClick: () -> Unit
+) {
+  val profileSlotWidth by
+      animateDpAsState(
+          targetValue = if (profileVisible) fieldHeight else 0.dp,
+          animationSpec =
+              tween(
+                  durationMillis = if (profileVisible) 220 else 180, easing = FastOutSlowInEasing),
+          label = "profileWidth")
+
+  val profileAlpha by
+      animateFloatAsState(
+          targetValue = if (profileVisible) 1f else 0f,
+          animationSpec =
+              tween(
+                  durationMillis = if (profileVisible) 220 else 180, easing = FastOutSlowInEasing),
+          label = "profileFade")
+
+  val slotPadding = if (profileSlotWidth > 0.dp) 12.dp else 0.dp
+
+  Box(
+      modifier = Modifier.padding(start = slotPadding).height(fieldHeight).width(profileSlotWidth),
+      contentAlignment = Alignment.Center) {
+        Surface(
+            modifier = Modifier.fillMaxSize().testTag("profileButton").alpha(profileAlpha),
+            color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f),
+            shape = RoundedCornerShape(16.dp)) {
+              Box(
+                  modifier =
+                      Modifier.fillMaxSize().clickable(enabled = profileVisible) {
+                        onProfileClick()
+                      },
+                  contentAlignment = Alignment.Center) {
+                    if (!avatarUrl.isNullOrEmpty() && avatarUrl.startsWith("http")) {
+                      AsyncImage(
+                          model = avatarUrl,
+                          contentDescription = "Profile Picture",
+                          contentScale = ContentScale.Crop,
+                          modifier = Modifier.fillMaxSize().clip(RoundedCornerShape(16.dp)))
+                    } else {
+                      Icon(
+                          imageVector = getAvatarIcon(avatarUrl),
+                          contentDescription = "Profile",
+                          modifier = Modifier.fillMaxSize(),
+                          tint = MaterialTheme.colorScheme.onSurface)
+                    }
+                  }
+            }
+      }
+}
+
+@Composable
+private fun SyncTextFieldValue(
+    value: String,
+    textFieldValueState: TextFieldValue,
+    onValueChange: (TextFieldValue) -> Unit
+) {
+  LaunchedEffect(value) {
+    if (textFieldValueState.text != value) {
+      onValueChange(TextFieldValue(text = value, selection = TextRange(value.length)))
+    }
+  }
+}
+
+@Composable
+private fun MoveCursorToEndOnFocus(
+    isFocused: Boolean,
+    value: String,
+    textFieldValueState: TextFieldValue,
+    onValueChange: (TextFieldValue) -> Unit
+) {
+  LaunchedEffect(isFocused, value) {
+    if (isFocused && value.isNotEmpty() && textFieldValueState.selection.start == 0) {
+      onValueChange(TextFieldValue(text = value, selection = TextRange(value.length)))
+    }
   }
 }
 

--- a/app/src/main/java/com/swent/mapin/ui/settings/ChangePasswordScreen.kt
+++ b/app/src/main/java/com/swent/mapin/ui/settings/ChangePasswordScreen.kt
@@ -70,6 +70,12 @@ import com.swent.mapin.ui.components.StandardTopAppBar
  */
 val PasswordVisibleKey = SemanticsPropertyKey<Boolean>("PasswordVisible")
 
+private enum class PasswordRequirementStatus {
+  NEUTRAL,
+  VALID,
+  INVALID
+}
+
 /**
  * Change Password screen allowing users to update their password.
  *
@@ -392,33 +398,52 @@ private fun PasswordRequirementItem(
     isValid: Boolean = false,
     showStatus: Boolean = false
 ) {
+  val status = resolvePasswordRequirementStatus(showStatus, isValid)
+  val textColor =
+      when (status) {
+        PasswordRequirementStatus.VALID -> Color(0xFF4CAF50)
+        PasswordRequirementStatus.INVALID -> MaterialTheme.colorScheme.error
+        PasswordRequirementStatus.NEUTRAL -> MaterialTheme.colorScheme.onSurfaceVariant
+      }
+
   Row(
       modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
       verticalAlignment = Alignment.CenterVertically) {
-        if (showStatus) {
-          // Show checkmark or cross based on validation
-          Icon(
-              imageVector = if (isValid) Icons.Default.Check else Icons.Default.Close,
-              contentDescription = if (isValid) "Requirement met" else "Requirement not met",
-              tint = if (isValid) Color(0xFF4CAF50) else MaterialTheme.colorScheme.error,
-              modifier = Modifier.size(16.dp))
-        } else {
-          // Show neutral dot when no input yet
-          Box(
-              modifier =
-                  Modifier.size(8.dp)
-                      .clip(CircleShape)
-                      .background(MaterialTheme.colorScheme.primary))
-        }
+        PasswordRequirementStatusIcon(status)
         Spacer(modifier = Modifier.padding(horizontal = 8.dp))
-        Text(
-            text = requirement,
-            style = MaterialTheme.typography.bodyMedium,
-            color =
-                when {
-                  showStatus && isValid -> Color(0xFF4CAF50)
-                  showStatus && !isValid -> MaterialTheme.colorScheme.error
-                  else -> MaterialTheme.colorScheme.onSurfaceVariant
-                })
+        Text(text = requirement, style = MaterialTheme.typography.bodyMedium, color = textColor)
       }
+}
+
+@Composable
+private fun PasswordRequirementStatusIcon(status: PasswordRequirementStatus) {
+  when (status) {
+    PasswordRequirementStatus.NEUTRAL -> {
+      Box(
+          modifier =
+              Modifier.size(8.dp).clip(CircleShape).background(MaterialTheme.colorScheme.primary))
+    }
+    PasswordRequirementStatus.VALID -> {
+      Icon(
+          imageVector = Icons.Default.Check,
+          contentDescription = "Requirement met",
+          tint = Color(0xFF4CAF50),
+          modifier = Modifier.size(16.dp))
+    }
+    PasswordRequirementStatus.INVALID -> {
+      Icon(
+          imageVector = Icons.Default.Close,
+          contentDescription = "Requirement not met",
+          tint = MaterialTheme.colorScheme.error,
+          modifier = Modifier.size(16.dp))
+    }
+  }
+}
+
+private fun resolvePasswordRequirementStatus(
+    showStatus: Boolean,
+    isValid: Boolean
+): PasswordRequirementStatus {
+  if (!showStatus) return PasswordRequirementStatus.NEUTRAL
+  return if (isValid) PasswordRequirementStatus.VALID else PasswordRequirementStatus.INVALID
 }

--- a/app/src/test/java/com/swent/mapin/ui/event/EventPickerDialogTest.kt
+++ b/app/src/test/java/com/swent/mapin/ui/event/EventPickerDialogTest.kt
@@ -1,0 +1,79 @@
+package com.swent.mapin.ui.event
+
+import com.google.firebase.Timestamp
+import com.swent.mapin.model.event.Event
+import com.swent.mapin.model.location.Location
+import java.util.Locale
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class EventPickerDialogTest {
+
+  private var defaultLocale: Locale = Locale.getDefault()
+
+  @Before
+  fun setUp() {
+    defaultLocale = Locale.getDefault()
+    Locale.setDefault(Locale.US)
+  }
+
+  @After
+  fun tearDown() {
+    Locale.setDefault(defaultLocale)
+  }
+
+  @Test
+  fun filterEvents_returnsAllWhenQueryBlank() {
+    val events = listOf(sampleEvent(title = "Sample"))
+
+    val result = filterEvents(events, "")
+
+    assertEquals(events, result)
+  }
+
+  @Test
+  fun filterEvents_matchesTitleDescriptionAndLocation() {
+    val events =
+        listOf(
+            sampleEvent(title = "Morning Run"),
+            sampleEvent(description = "Great food here"),
+            sampleEvent(location = Location(name = "Library", latitude = 0.0, longitude = 0.0)))
+
+    val byTitle = filterEvents(events, "run")
+    val byDescription = filterEvents(events, "food")
+    val byLocation = filterEvents(events, "library")
+
+    assertEquals(1, byTitle.size)
+    assertEquals("Morning Run", byTitle.first().title)
+
+    assertEquals(1, byDescription.size)
+    assertTrue(byDescription.first().description.contains("food", ignoreCase = true))
+
+    assertEquals(1, byLocation.size)
+    assertEquals("Library", byLocation.first().location.name)
+  }
+
+  @Test
+  fun formatEventDate_formatsAsMonthDayYear() {
+    val timestamp = Timestamp(1704067200, 0) // Jan 1, 2024 00:00:00 UTC
+
+    val formatted = formatEventDate(timestamp)
+
+    assertEquals("Jan 01, 2024", formatted)
+  }
+
+  private fun sampleEvent(
+      title: String = "",
+      description: String = "",
+      location: Location = Location(name = null, latitude = null, longitude = null, geohash = null)
+  ): Event {
+    return Event(
+        uid = title.ifBlank { "id_${description.hashCode()}" },
+        title = title,
+        description = description,
+        location = location)
+  }
+}


### PR DESCRIPTION
## Description
Refactors search UI components and EventPickerDialog to reduce complexity and adds unit/UI coverage for the picker.

**Related Issue:** N/A

---

## Changes

**Implementation:**
- Split SearchBar into focused composables/helpers for text sync, trailing icon, and profile slot handling.
- Simplified ChangePasswordScreen password requirement rendering with a status enum/icon helper.
- Refactored EventPickerDialog into smaller composables with test tags and exposed helpers for filtering/date formatting.

**Tests:**
- `./gradlew :app:testDebugUnitTest --tests com.swent.mapin.ui.event.EventPickerDialogTest`
- `./gradlew :app:connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.swent.mapin.ui.event.EventPickerDialogAndroidTest`

---

## Testing
- [x] Unit tests pass
- [x] Instrumentation tests pass
- [ ] Manual testing completed
- [ ] Coverage maintained (≥80%)

**Test summary:** Ran EventPickerDialog unit and targeted Compose instrumentation tests after refactors.

---

## Screenshots/Videos
N/A

---

## Checklist
- [x] Sufficient documentation and minimal inline comments
- [x] All tests passing
- [x] No new warnings
- [ ] If related issue exists: issue has all labels, fields, and milestone filled
