### PR TITLE
Fix filters not showing during sheet transition

### DIFF
--- a/app/src/main/java/com/swent/mapin/ui/map/BottomSheetContent.kt
+++ b/app/src/main/java/com/swent/mapin/ui/map/BottomSheetContent.kt
@@ -472,14 +472,11 @@ fun BottomSheetContent(
 
                                 Spacer(modifier = Modifier.height(12.dp))
 
-                                if (isFull) {
-                                  // Avoid running filter side effects when sheet is not fully shown
-                                  filterSection.Render(
-                                      Modifier.fillMaxWidth(),
-                                      filterViewModel,
-                                      locationViewModel,
-                                      userProfile)
-                                }
+                                filterSection.Render(
+                                    Modifier.fillMaxWidth(),
+                                    filterViewModel,
+                                    locationViewModel,
+                                    userProfile)
 
                                 Spacer(modifier = Modifier.height(16.dp))
 


### PR DESCRIPTION
## Summary
- Filters now always render in the bottom sheet content
- Fixes blank content appearing during drag from collapsed/medium to full

🤖 Generated with [Claude Code](https://claude.com/claude-code)